### PR TITLE
[WIP] Fix build for ARM target

### DIFF
--- a/target/arm/translate.c
+++ b/target/arm/translate.c
@@ -5535,12 +5535,12 @@ static bool op_s_rri_rot(DisasContext *s, arg_s_rri_rot *a,
       TCGv tmp1_64 = tcg_temp_new();
       TCGv tmp2_64 = tcg_temp_new();
       tcg_gen_extu_i32_i64(tmp1_64, tmp1);
-      tcg_gen_extu_i32_i64(tmp2_64, tmp2);
+      tcg_gen_extu_i32_i64(tmp2_64, tcg_constant_i32(imm));
       libafl_gen_cmp(s->pc_curr, tmp1_64, tmp2_64, MO_32);
       tcg_temp_free(tmp1_64);
       tcg_temp_free(tmp2_64);
 #else
-      libafl_gen_cmp(s->pc_curr, tmp1, tmp2, MO_32);
+      libafl_gen_cmp(s->pc_curr, tmp1, tcg_constant_i32(imm), MO_32);
 #endif
     }
 


### PR DESCRIPTION
Currently, does not seem to build for the ARM target, and probably also not aarch64, due to a copy-paste error:

```
../target/arm/translate.c: In function ‘op_s_rri_rot’:
../target/arm/translate.c:5543:40: error: ‘tmp2’ undeclared (first use in this function); did you mean ‘tmp1’?
 5543 |       libafl_gen_cmp(s->pc_curr, tmp1, tmp2, MO_32);
      |                                        ^~~~
      |                                        tmp1
```

This seems to fix the build. However, I am not sure the current code makes sense, since it seems to be a comparison with a (possibly) rotated immediate value. Not sure there need to be cmplog hooks placed on that?