### PR TITLE
Fixing libafl_add_backdoor input type for 32-bit targets

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -674,7 +674,7 @@ struct libafl_backdoor_hook* libafl_backdoor_hooks;
 
 void libafl_add_backdoor_hook(void (*exec)(target_ulong pc, uint64_t data),
                               uint64_t data);
-void libafl_add_backdoor_hook(void (*exec)(uint64_t id, uint64_t data),
+void libafl_add_backdoor_hook(void (*exec)(target_ulong id, uint64_t data),
                               uint64_t data)
 {
     struct libafl_backdoor_hook* hook = malloc(sizeof(struct libafl_backdoor_hook));


### PR DESCRIPTION
Works:
```
../configure --as-shared-lib --target-list=x86_64-linux-user --disable-blobs --disable-bsd-user --disable-fdt
make -j
```

Doesn't works:
```
../configure --as-shared-lib --target-list=arm-linux-user --disable-blobs --disable-bsd-user --disable-fdt
make -j
```