### PR TITLE
Fixing wildcard in configure

### DIFF
--- a/configure
+++ b/configure
@@ -960,11 +960,6 @@ for opt do
       QEMU_CFLAGS="$QEMU_CFLAGS -fPIC -DAS_LIB=1"
       QEMU_CXXFLAGS="$QEMU_CXXFLAGS -fPIC -DAS_LIB=1"
   ;;
-  *)
-      echo "ERROR: unknown option $opt"
-      echo "Try '$0 --help' for more information"
-      exit 1
-  ;;
   # everything else has the same name in configure and meson
   --*) meson_option_parse "$opt" "$optarg"
   ;;


### PR DESCRIPTION
Removing the wildcard for configuration flags, enabling QEMU meson flags. 

Problem:
`./configure --help` indicated that additional flags will be passed through to meson. `./configure --disable-tmp` should be handled by meson, but throws an error due to the wildcard in front of it in the configure file. Probably a merge issue as the QEMU vanilla repo does not have this wildcard.