### PR TITLE
fixing standalone gdb break exit

### DIFF
--- a/softmmu/runstate.c
+++ b/softmmu/runstate.c
@@ -669,9 +669,9 @@ static bool main_loop_should_exit(int *status)
         vm_stop(RUN_STATE_DEBUG);
 
 //// --- Begin LibAFL code ---
-
+#ifdef AS_LIB
         return true;    // exit back to fuzzing harness
-
+#endif
 //// --- End LibAFL code ---
 
     }


### PR DESCRIPTION
currently, if you build qemu as standalone, you won't be able to use gdb because it will exit after breakpoint. this will fix that.