### PR TITLE
Hexagon support

### DIFF
--- a/linux-user/hexagon/cpu_loop.c
+++ b/linux-user/hexagon/cpu_loop.c
@@ -33,12 +33,29 @@ void cpu_loop(CPUHexagonState *env)
     target_ulong ret;
 
     for (;;) {
+
+//// --- Begin LibAFL code ---
+
+        if (libafl_qemu_break_asap) return;
+
+//// --- End LibAFL code ---
+
         cpu_exec_start(cs);
         trapnr = cpu_exec(cs);
         cpu_exec_end(cs);
         process_queued_cpu_work(cs);
 
         switch (trapnr) {
+
+//// --- Begin LibAFL code ---
+
+#define EXCP_LIBAFL_BP 0xf4775747
+
+        case EXCP_LIBAFL_BP:
+            return;
+
+//// --- End LibAFL code ---
+
         case EXCP_INTERRUPT:
             /* just indicate that signals should be handled asap */
             break;

--- a/target/hexagon/cpu-param.h
+++ b/target/hexagon/cpu-param.h
@@ -18,7 +18,16 @@
 #ifndef HEXAGON_CPU_PARAM_H
 #define HEXAGON_CPU_PARAM_H
 
-#define TARGET_PAGE_BITS 16     /* 64K pages */
+//// --- Begin LibAFL code ---
+
+/* Binearies that assume 4k page size were observed.
+   Unless TARGET_PAGE_BITS is reduced, Qemu elf loader
+   will error out for such binaries. */
+//#define TARGET_PAGE_BITS 16     /* 64K pages */
+#define TARGET_PAGE_BITS 12     /* 4K pages */
+
+//// --- End LibAFL code ---
+
 #define TARGET_LONG_BITS 32
 
 #define TARGET_PHYS_ADDR_SPACE_BITS 36

--- a/target/hexagon/cpu-param.h
+++ b/target/hexagon/cpu-param.h
@@ -20,7 +20,7 @@
 
 //// --- Begin LibAFL code ---
 
-/* Binearies that assume 4k page size were observed.
+/* Binaries that assume 4k page size were observed.
    Unless TARGET_PAGE_BITS is reduced, Qemu elf loader
    will error out for such binaries. */
 //#define TARGET_PAGE_BITS 16     /* 64K pages */


### PR DESCRIPTION
This is the first part of a patch to support Qualcomm Hexagon architecture in LibAFL. The second part (with the changes to LibAFL repo) is on the way.

I'm not the biggest fan of the changes made to the .elf loader as they feel somewhat hacky, however at least the binary I was analyzing would not load without them.
