### PR TITLE
Fix wrong dirty address tracking for MMIO accesses. Assert is only triggered for debug builds.

### DIFF
--- a/accel/tcg/cputlb.c
+++ b/accel/tcg/cputlb.c
@@ -1830,7 +1830,8 @@ static bool mmu_lookup(CPUState *cpu, vaddr addr, MemOpIdx oi,
 
         //// --- Begin LibAFL code ---
 
-        if (type == MMU_DATA_STORE) {
+        // TODO: check if the second condition solves faulty dirty address report
+        if (type == MMU_DATA_STORE && !(flags & (TLB_INVALID_MASK | TLB_MMIO))) {
             syx_snapshot_dirty_list_add_hostaddr(l->page[0].haddr);
         }
 

--- a/libafl_extras/syx-snapshot/syx-snapshot.c
+++ b/libafl_extras/syx-snapshot/syx-snapshot.c
@@ -393,7 +393,9 @@ void syx_snapshot_dirty_list_add_hostaddr(void* host_addr) {
     ram_addr_t offset;
     RAMBlock* rb = qemu_ram_block_from_host((void*) host_addr, true, &offset);
 
+#ifdef CONFIG_DEBUG_TCG
     assert(rb);
+#endif
     
     hwaddr paddr = rb->mr->addr + offset;
     // If this assert is ever false, please understand why

--- a/libafl_extras/syx-snapshot/syx-snapshot.c
+++ b/libafl_extras/syx-snapshot/syx-snapshot.c
@@ -395,6 +395,10 @@ void syx_snapshot_dirty_list_add_hostaddr(void* host_addr) {
 
 #ifdef CONFIG_DEBUG_TCG
     assert(rb);
+#else
+    if (!rb) {
+        return;
+    }
 #endif
     
     hwaddr paddr = rb->mr->addr + offset;


### PR DESCRIPTION
It is still required to check whether the fix is enough to avoid wrong dirty page reports.
For now, the assert is ignored in release builds. 