### PR TITLE
Fix of syx_snapshot_dirty_list_add_hostaddr_range

### DIFF
--- a/libafl_extras/syx-snapshot/syx-snapshot.c
+++ b/libafl_extras/syx-snapshot/syx-snapshot.c
@@ -451,6 +451,11 @@ void syx_snapshot_dirty_list_add_hostaddr(void* host_addr)
 
 void syx_snapshot_dirty_list_add_hostaddr_range(void* host_addr, uint64_t len)
 {
+    // early check to know whether we should log the page access or not
+    if (!syx_snapshot_is_enabled()) {
+        return;
+    }
+
     assert(len < INT64_MAX);
     int64_t len_signed = (int64_t) len;
 


### PR DESCRIPTION
Check if snapshot is enabled before logging also in range version of dirty_list_add.