### PR TITLE
Internal exit

### DIFF
--- a/libafl_extras/exit.c
+++ b/libafl_extras/exit.c
@@ -97,6 +97,17 @@ CPUState* libafl_last_exit_cpu(void)
     return NULL;
 }
 
+void libafl_exit_request_internal(CPUState* cpu, uint64_t pc, ShutdownCause cause, int signal)
+{
+    last_exit_reason.kind = INTERNAL;
+    last_exit_reason.data.internal.cause = cause;
+    last_exit_reason.data.internal.signal = signal;
+
+    last_exit_reason.cpu = cpu;
+    last_exit_reason.next_pc = pc;
+    expected_exit = true;
+}
+
 void libafl_exit_request_sync_backdoor(CPUState* cpu, target_ulong pc)
 {
     last_exit_reason.kind = SYNC_BACKDOOR;

--- a/libafl_extras/exit.h
+++ b/libafl_extras/exit.h
@@ -19,21 +19,31 @@ int libafl_qemu_set_breakpoint(target_ulong pc);
 int libafl_qemu_remove_breakpoint(target_ulong pc);
 
 enum libafl_exit_reason_kind {
-    BREAKPOINT = 0,
-    SYNC_BACKDOOR = 1,
+    INTERNAL = 0,
+    BREAKPOINT = 1,
+    SYNC_BACKDOOR = 2,
 };
 
+// A breakpoint has been triggered.
 struct libafl_exit_reason_breakpoint {
     target_ulong addr;
 };
 
+// A synchronous exit has been triggered.
 struct libafl_exit_reason_sync_backdoor { };
+
+// QEMU exited on its own for some reason.
+struct libafl_exit_reason_internal {
+    ShutdownCause cause;
+    int signal; // valid if cause == SHUTDOWN_CAUSE_HOST_SIGNAL
+};
 
 struct libafl_exit_reason {
     enum libafl_exit_reason_kind kind;
     CPUState* cpu; // CPU that triggered an exit.
     vaddr next_pc; // The PC that should be stored in the CPU when re-entering.
     union {
+        struct libafl_exit_reason_internal internal;
         struct libafl_exit_reason_breakpoint breakpoint; // kind == BREAKPOINT
         struct libafl_exit_reason_sync_backdoor backdoor; // kind == SYNC_BACKDOOR
     } data;
@@ -47,6 +57,7 @@ void libafl_exit_signal_vm_start(void);
 bool libafl_exit_asap(void);
 void libafl_sync_exit_cpu(void);
 
+void libafl_exit_request_internal(CPUState* cpu, uint64_t pc, ShutdownCause cause, int signal);
 void libafl_exit_request_sync_backdoor(CPUState* cpu, target_ulong pc);
 void libafl_exit_request_breakpoint(CPUState* cpu, target_ulong pc);
 struct libafl_exit_reason* libafl_get_exit_reason(void);


### PR DESCRIPTION
Added qemu internal exit reason.
It's used when QEMU exits on its own.
It can be used to catch QEMU guest crashes or exits due to signals.