### PR TITLE
restore `libafl_qemu_trigger_breakpoint` symbol

### DIFF
--- a/libafl_extras/exit.c
+++ b/libafl_extras/exit.c
@@ -123,6 +123,12 @@ void libafl_exit_request_breakpoint(CPUState* cpu, target_ulong pc)
     prepare_qemu_exit(cpu, pc);
 }
 
+void libafl_qemu_trigger_breakpoint(CPUState* cpu)
+{
+    CPUClass* cc = CPU_GET_CLASS(cpu);
+    libafl_exit_request_breakpoint(cpu, cc->get_pc(cpu));
+}
+
 void libafl_exit_signal_vm_start(void)
 {
     last_exit_reason.cpu = NULL;

--- a/libafl_extras/exit.h
+++ b/libafl_extras/exit.h
@@ -17,6 +17,7 @@ void libafl_breakpoint_invalidate(CPUState *cpu, target_ulong pc);
 
 int libafl_qemu_set_breakpoint(target_ulong pc);
 int libafl_qemu_remove_breakpoint(target_ulong pc);
+void libafl_qemu_trigger_breakpoint(CPUState* cpu);
 
 enum libafl_exit_reason_kind {
     INTERNAL = 0,


### PR DESCRIPTION
Restored `libafl_qemu_trigger_breakpoint` symbol deleted in PR #30 