### PR TITLE
clone: fix stack use after scope

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -6563,9 +6563,10 @@ static void *clone_func(void *arg)
     libafl_qemu_env = env;
     if (libafl_new_thread_hooks) {
         bool continue_execution = true;
+        int tid = sys_gettid();
         struct libafl_new_thread_hook* h = libafl_new_thread_hooks;
         while (h) {
-            continue_execution = h->callback(h->data, info->tid) && continue_execution;
+            continue_execution = h->callback(h->data, tid) && continue_execution;
             h = h->next;
         }
         if (continue_execution) cpu_loop(env);


### PR DESCRIPTION
In QEMU's code handling `clone`, when `clone` creates a new thread, it does some QEMU stuff, creates a conditional variable and spawns a new thread.
https://github.com/AFLplusplus/qemu-libafl-bridge/blob/99ea52d12369d0bd30717c57e65719a2644b7c68/linux-user/syscall.c#L6647-L6683
The thread fills the data that'll be `clone`'s return value, and trigger the conditional variable.
https://github.com/AFLplusplus/qemu-libafl-bridge/blob/99ea52d12369d0bd30717c57e65719a2644b7c68/linux-user/syscall.c#L6544-L6568
When the `clone`'s caller gets unlocked, the info soon gets out of scope.
Then if LibAFL hooks are called, it accesses the freed-then-reused stack memory which contains trash.