### PR TITLE
Add tcg_env to backdoor callback

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, qemu]
     container: registry.gitlab.com/qemu-project/qemu/qemu/ubuntu2204:latest
     steps:
       - uses: actions/checkout@v4

--- a/accel/tcg/translator.c
+++ b/accel/tcg/translator.c
@@ -219,22 +219,12 @@ void translator_loop(CPUState *cpu, TranslationBlock *tb, int *max_insns,
                     if (backdoor == 0x44) {
                         struct libafl_backdoor_hook* bhk = libafl_backdoor_hooks;
                         while (bhk) {
-                            TCGv_i64 tmp0 = tcg_constant_i64(bhk->data);
-#if TARGET_LONG_BITS == 32
-                            TCGv_i32 tmp1 = tcg_constant_i32(db->pc_next);
-                            TCGTemp *tmp2[2] = { tcgv_i64_temp(tmp0), tcgv_i32_temp(tmp1) };
-#else
-                            TCGv_i64 tmp1 = tcg_constant_i64(db->pc_next);
-                            TCGTemp *tmp2[2] = { tcgv_i64_temp(tmp0), tcgv_i64_temp(tmp1) };
-#endif
-                            // tcg_gen_callN(bhk->exec, NULL, 2, tmp2);
-                            tcg_gen_callN(&bhk->helper_info, NULL, tmp2);
-#if TARGET_LONG_BITS == 32
-                            tcg_temp_free_i32(tmp1);
-#else
-                            tcg_temp_free_i64(tmp1);
-#endif
-                            tcg_temp_free_i64(tmp0);
+                            TCGv_i64 tmp1 = tcg_constant_i64(bhk->data);
+                            TCGv tmp2 = tcg_constant_tl(db->pc_next);
+                            TCGTemp *args[3] = { tcgv_ptr_temp(tcg_env), tcgv_i64_temp(tmp1), tcgv_tl_temp(tmp2) };
+
+                            tcg_gen_callN(&bhk->helper_info, NULL, args);
+
                             bhk = bhk->next;
                         }
 

--- a/accel/tcg/translator.c
+++ b/accel/tcg/translator.c
@@ -219,9 +219,9 @@ void translator_loop(CPUState *cpu, TranslationBlock *tb, int *max_insns,
                     if (backdoor == 0x44) {
                         struct libafl_backdoor_hook* bhk = libafl_backdoor_hooks;
                         while (bhk) {
-                            TCGv_i64 tmp1 = tcg_constant_i64(bhk->data);
+                            TCGv_i64 tmp0 = tcg_constant_i64(bhk->data);
                             TCGv tmp2 = tcg_constant_tl(db->pc_next);
-                            TCGTemp *args[3] = { tcgv_ptr_temp(tcg_env), tcgv_i64_temp(tmp1), tcgv_tl_temp(tmp2) };
+                            TCGTemp *args[3] = { tcgv_i64_temp(tmp0), tcgv_ptr_temp(tcg_env), tcgv_tl_temp(tmp2) };
 
                             tcg_gen_callN(&bhk->helper_info, NULL, args);
 

--- a/include/tcg/tcg-op.h
+++ b/include/tcg/tcg-op.h
@@ -53,15 +53,19 @@ typedef TCGv_i32 TCGv;
 #define tcg_temp_new() tcg_temp_new_i32()
 #define tcg_global_mem_new tcg_global_mem_new_i32
 #define tcgv_tl_temp tcgv_i32_temp
+#define temp_tcgv_tl temp_tcgv_i32
 #define tcg_gen_qemu_ld_tl tcg_gen_qemu_ld_i32
 #define tcg_gen_qemu_st_tl tcg_gen_qemu_st_i32
+#define tcg_gen_tl_ptr tcg_gen_ext_i32_ptr
 #elif TARGET_LONG_BITS == 64
 typedef TCGv_i64 TCGv;
 #define tcg_temp_new() tcg_temp_new_i64()
 #define tcg_global_mem_new tcg_global_mem_new_i64
 #define tcgv_tl_temp tcgv_i64_temp
+#define temp_tcgv_tl temp_tcgv_i64
 #define tcg_gen_qemu_ld_tl tcg_gen_qemu_ld_i64
 #define tcg_gen_qemu_st_tl tcg_gen_qemu_st_i64
+#define tcg_gen_tl_ptr tcg_gen_trunc_i64_ptr
 #else
 #error Unhandled TARGET_LONG_BITS value
 #endif

--- a/libafl_extras/hook.c
+++ b/libafl_extras/hook.c
@@ -342,7 +342,7 @@ static TCGHelperInfo libafl_exec_write_hookN_info = {
 struct libafl_rw_hook* libafl_read_hooks;
 size_t libafl_read_hooks_num = 0;
 
-size_t libafl_add_read_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, MemOpIdx oi),
+size_t libafl_add_read_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, TCGTemp *addr, MemOpIdx oi),
                              void (*exec1)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec2)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec4)(uint64_t data, uint64_t id, target_ulong addr),
@@ -396,7 +396,7 @@ GEN_REMOVE_HOOK(read)
 struct libafl_rw_hook* libafl_write_hooks;
 size_t libafl_write_hooks_num = 0;
 
-size_t libafl_add_write_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, MemOpIdx oi),
+size_t libafl_add_write_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, TCGTemp *addr, MemOpIdx oi),
                              void (*exec1)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec2)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec4)(uint64_t data, uint64_t id, target_ulong addr),
@@ -454,7 +454,7 @@ static void libafl_gen_rw(TCGTemp *addr, MemOpIdx oi, struct libafl_rw_hook* hoo
     while (hook) {
         uint64_t cur_id = 0;
         if (hook->gen)
-            cur_id = hook->gen(hook->data, libafl_gen_cur_pc, oi);
+            cur_id = hook->gen(hook->data, libafl_gen_cur_pc, addr, oi);
         TCGHelperInfo* info = NULL;
         if (size == 1 && hook->helper_info1.func) info = &hook->helper_info1;
         else if (size == 2 && hook->helper_info2.func) info = &hook->helper_info2;
@@ -687,3 +687,59 @@ size_t libafl_add_new_thread_hook(bool (*callback)(uint64_t data, uint32_t tid),
 }
 
 GEN_REMOVE_HOOK1(new_thread)
+
+#if TARGET_LONG_BITS == 32
+#define SHADOW_BASE (0x20000000)
+#elif TARGET_LONG_BITS == 64
+#define SHADOW_BASE (0x7fff8000)
+#else
+#error Unhandled TARGET_LONG_BITS value
+#endif
+
+void libafl_tcg_gen_asan(TCGTemp * addr, size_t size)
+{
+    if (size == 0)
+        return;
+        
+    TCGv addr_val = temp_tcgv_tl(addr);
+    TCGv k = tcg_temp_new();
+    TCGv shadow_addr = tcg_temp_new();
+    TCGv_ptr shadow_ptr = tcg_temp_new_ptr();
+    TCGv shadow_val = tcg_temp_new();
+    TCGv test_addr = tcg_temp_new();
+    TCGv_ptr test_ptr = tcg_temp_new_ptr();    
+
+    tcg_gen_andi_tl(k, addr_val, 7);
+    tcg_gen_addi_tl(k, k, size - 1);
+
+    tcg_gen_shri_tl(shadow_addr, addr_val, 3);
+    tcg_gen_addi_tl(shadow_addr, shadow_addr, SHADOW_BASE);
+    tcg_gen_tl_ptr(shadow_ptr, shadow_addr);
+    tcg_gen_ld8s_tl(shadow_val, shadow_ptr, 0);
+
+    /*
+     * Making conditional branches here appears to cause QEMU issues with dead
+     * temporaries so we will instead avoid branches. We will cause the guest
+     * to perform a NULL dereference in the event of an ASAN fault. Note that
+     * we will do this by using a store rather than a load, since the TCG may
+     * otherwise determine that the result of the load is unused and simply
+     * discard the operation. In the event that the shadow memory doesn't
+     * detect a fault, we will simply write the value read from the shadow
+     * memory back to it's original location. If, however, the shadow memory
+     * detects an invalid access, we will instead attempt to write the value
+     * at 0x0.
+     */
+    tcg_gen_movcond_tl(TCG_COND_EQ, test_addr,
+        shadow_val, tcg_constant_tl(0),
+        shadow_addr, tcg_constant_tl(0));
+
+    if (size < 8)
+    {
+        tcg_gen_movcond_tl(TCG_COND_GE, test_addr,
+            k, shadow_val,
+            test_addr, shadow_addr);
+    }
+
+    tcg_gen_tl_ptr(test_ptr, test_addr);
+    tcg_gen_st8_tl(shadow_val, test_ptr, 0);
+}

--- a/libafl_extras/hook.c
+++ b/libafl_extras/hook.c
@@ -169,7 +169,7 @@ static TCGHelperInfo libafl_exec_backdoor_hook_info = {
 struct libafl_backdoor_hook* libafl_backdoor_hooks;
 size_t libafl_backdoor_hooks_num = 0;
 
-size_t libafl_add_backdoor_hook(void (*exec)(CPUArchState* cpu, uint64_t data, target_ulong pc),
+size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, CPUArchState* cpu, target_ulong pc),
                                 uint64_t data)
 {
     struct libafl_backdoor_hook* hook = calloc(sizeof(struct libafl_backdoor_hook), 1);

--- a/libafl_extras/hook.c
+++ b/libafl_extras/hook.c
@@ -157,17 +157,19 @@ int libafl_qemu_remove_##name##_hook(size_t num) \
     return  0; \
 }
 
-
 static TCGHelperInfo libafl_exec_backdoor_hook_info = {
-    .func = NULL, .name = "libafl_exec_backdoor_hook", \
-    .flags = dh_callflag(void), \
-    .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(tl, 2)
+    .func = NULL, .name = "libafl_exec_backdoor_hook",
+    .flags = dh_callflag(void),
+    .typemask = dh_typemask(void, 0)
+                | dh_typemask(env, 1)
+                | dh_typemask(i64, 2)
+                | dh_typemask(tl, 3)
 };
 
 struct libafl_backdoor_hook* libafl_backdoor_hooks;
 size_t libafl_backdoor_hooks_num = 0;
 
-size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, target_ulong pc),
+size_t libafl_add_backdoor_hook(void (*exec)(CPUArchState* cpu, uint64_t data, target_ulong pc),
                                 uint64_t data)
 {
     struct libafl_backdoor_hook* hook = calloc(sizeof(struct libafl_backdoor_hook), 1);
@@ -186,8 +188,8 @@ size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, target_ulong pc),
 GEN_REMOVE_HOOK(backdoor)
 
 static TCGHelperInfo libafl_exec_edge_hook_info = {
-    .func = NULL, .name = "libafl_exec_edge_hook", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_edge_hook",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2)
 };
 
@@ -285,54 +287,54 @@ bool libafl_qemu_block_hook_set_jit(size_t num, size_t (*jit)(uint64_t data, uin
 }
 
 static TCGHelperInfo libafl_exec_read_hook1_info = {
-    .func = NULL, .name = "libafl_exec_read_hook1", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_read_hook1",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_read_hook2_info = {
-    .func = NULL, .name = "libafl_exec_read_hook2", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_read_hook2",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_read_hook4_info = {
-    .func = NULL, .name = "libafl_exec_read_hook4", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_read_hook4",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_read_hook8_info = {
-    .func = NULL, .name = "libafl_exec_read_hook8", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_read_hook8",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_read_hookN_info = {
-    .func = NULL, .name = "libafl_exec_read_hookN", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_read_hookN",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2)
                 | dh_typemask(tl, 3) | dh_typemask(i64, 4)
 };
 static TCGHelperInfo libafl_exec_write_hook1_info = {
-    .func = NULL, .name = "libafl_exec_write_hook1", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_write_hook1",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_write_hook2_info = {
-    .func = NULL, .name = "libafl_exec_write_hook2", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_write_hook2",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_write_hook4_info = {
-    .func = NULL, .name = "libafl_exec_write_hook4", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_write_hook4",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_write_hook8_info = {
-    .func = NULL, .name = "libafl_exec_write_hook8", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_write_hook8",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2) | dh_typemask(tl, 3)
 };
 static TCGHelperInfo libafl_exec_write_hookN_info = {
-    .func = NULL, .name = "libafl_exec_write_hookN", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_write_hookN",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2)
                 | dh_typemask(tl, 3) | dh_typemask(i64, 4)
 };
@@ -505,26 +507,26 @@ void libafl_gen_write(TCGTemp *addr, MemOpIdx oi)
 }
 
 static TCGHelperInfo libafl_exec_cmp_hook1_info = {
-    .func = NULL, .name = "libafl_exec_cmp_hook1", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_cmp_hook1",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1)
     | dh_typemask(i64, 2) | dh_typemask(tl, 3) | dh_typemask(tl, 4)
 };
 static TCGHelperInfo libafl_exec_cmp_hook2_info = {
-    .func = NULL, .name = "libafl_exec_cmp_hook2", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_cmp_hook2",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1)
     | dh_typemask(i64, 2) | dh_typemask(tl, 3) | dh_typemask(tl, 4)
 };
 static TCGHelperInfo libafl_exec_cmp_hook4_info = {
-    .func = NULL, .name = "libafl_exec_cmp_hook4", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_cmp_hook4",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1)
     | dh_typemask(i64, 2) | dh_typemask(tl, 3) | dh_typemask(tl, 4)
 };
 static TCGHelperInfo libafl_exec_cmp_hook8_info = {
-    .func = NULL, .name = "libafl_exec_cmp_hook8", \
-    .flags = dh_callflag(void), \
+    .func = NULL, .name = "libafl_exec_cmp_hook8",
+    .flags = dh_callflag(void),
     .typemask = dh_typemask(void, 0) | dh_typemask(i64, 1)
     | dh_typemask(i64, 2) | dh_typemask(i64, 3) | dh_typemask(i64, 4)
 };

--- a/libafl_extras/hook.h
+++ b/libafl_extras/hook.h
@@ -93,7 +93,7 @@ int libafl_qemu_remove_block_hook(size_t num, int invalidate);
 bool libafl_qemu_block_hook_set_jit(size_t num, size_t (*jit)(uint64_t, uint64_t)); // no param names to avoid to be marked as safe
 
 struct libafl_rw_hook {
-    uint64_t (*gen)(uint64_t data, target_ulong pc, MemOpIdx oi);
+    uint64_t (*gen)(uint64_t data, target_ulong pc, TCGTemp* addr, MemOpIdx oi);
     /*void (*exec1)(uint64_t data, uint64_t id, target_ulong addr);
     void (*exec2)(uint64_t data, uint64_t id, target_ulong addr);
     void (*exec4)(uint64_t data, uint64_t id, target_ulong addr);
@@ -116,14 +116,14 @@ struct libafl_rw_hook {
 extern struct libafl_rw_hook* libafl_read_hooks;
 extern struct libafl_rw_hook* libafl_write_hooks;
 
-size_t libafl_add_read_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, MemOpIdx oi),
+size_t libafl_add_read_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, TCGTemp *addr, MemOpIdx oi),
                              void (*exec1)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec2)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec4)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec8)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*execN)(uint64_t data, uint64_t id, target_ulong addr, size_t size),
                              uint64_t data);
-size_t libafl_add_write_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, MemOpIdx oi),
+size_t libafl_add_write_hook(uint64_t (*gen)(uint64_t data, target_ulong pc, TCGTemp *addr, MemOpIdx oi),
                              void (*exec1)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec2)(uint64_t data, uint64_t id, target_ulong addr),
                              void (*exec4)(uint64_t data, uint64_t id, target_ulong addr),
@@ -222,3 +222,5 @@ extern struct libafl_new_thread_hook* libafl_new_thread_hooks;
 size_t libafl_add_new_thread_hook(bool (*callback)(uint64_t data, uint32_t tid),
                                   uint64_t data);
 int libafl_qemu_remove_new_thread_hook(size_t num);
+
+void libafl_tcg_gen_asan(TCGTemp * addr, size_t size);

--- a/libafl_extras/hook.h
+++ b/libafl_extras/hook.h
@@ -41,7 +41,7 @@ int libafl_qemu_remove_hook(size_t num, int invalidate);
 struct libafl_hook* libafl_search_hook(target_ulong addr);
 
 struct libafl_backdoor_hook {
-    void (*exec)(uint64_t data, target_ulong pc);
+    void (*exec)(CPUArchState* cpu, uint64_t data, target_ulong pc);
     uint64_t data;
     size_t num;
     TCGHelperInfo helper_info;
@@ -50,7 +50,7 @@ struct libafl_backdoor_hook {
 
 extern struct libafl_backdoor_hook* libafl_backdoor_hooks;
 
-size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, target_ulong pc),
+size_t libafl_add_backdoor_hook(void (*exec)(CPUArchState* cpu, uint64_t data, target_ulong pc),
                                 uint64_t data);
 int libafl_qemu_remove_backdoor_hook(size_t num, int invalidate);
 

--- a/libafl_extras/hook.h
+++ b/libafl_extras/hook.h
@@ -41,7 +41,7 @@ int libafl_qemu_remove_hook(size_t num, int invalidate);
 struct libafl_hook* libafl_search_hook(target_ulong addr);
 
 struct libafl_backdoor_hook {
-    void (*exec)(CPUArchState* cpu, uint64_t data, target_ulong pc);
+    void (*exec)(uint64_t data, CPUArchState* cpu, target_ulong pc);
     uint64_t data;
     size_t num;
     TCGHelperInfo helper_info;
@@ -50,7 +50,7 @@ struct libafl_backdoor_hook {
 
 extern struct libafl_backdoor_hook* libafl_backdoor_hooks;
 
-size_t libafl_add_backdoor_hook(void (*exec)(CPUArchState* cpu, uint64_t data, target_ulong pc),
+size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, CPUArchState* cpu, target_ulong pc),
                                 uint64_t data);
 int libafl_qemu_remove_backdoor_hook(size_t num, int invalidate);
 


### PR DESCRIPTION
Note we do not need to free constant tcg temps (they are ignored by  `tcg_temp_free_internal` anyway).
For information, they are being garbage collected in `la_bb_end`.