### PR TITLE
Fix libafl_qemu_read_reg and libafl_qemu_write_reg

### DIFF
--- a/gdbstub/gdbstub.c
+++ b/gdbstub/gdbstub.c
@@ -533,7 +533,12 @@ int gdb_read_register(CPUState *cpu, GByteArray *buf, int reg)
     return 0;
 }
 
-static int gdb_write_register(CPUState *cpu, uint8_t *mem_buf, int reg)
+
+//// --- Begin LibAFL code ---
+int gdb_write_register(CPUState *cpu, uint8_t *mem_buf, int reg);
+/* static */
+//// --- End LibAFL code ---
+int gdb_write_register(CPUState *cpu, uint8_t *mem_buf, int reg)
 {
     CPUClass *cc = CPU_GET_CLASS(cpu);
     GDBRegisterState *r;


### PR DESCRIPTION
GDB does not always relies on `gdb_num_core_regs` to read / write. 
Use qemu primitives instead to cover all cases.