### PR TITLE
Unset object to free memory space allocated (memory leak)

### DIFF
--- a/io/channel-buffer.c
+++ b/io/channel-buffer.c
@@ -35,11 +35,11 @@ qio_channel_buffer_new(size_t capacity)
     if (capacity) {
         ioc->data = g_new0(uint8_t, capacity);
         ioc->capacity = capacity;
-        
-        //// --- Begin LibAFL code ---
-        ioc->internal_allocation = true;
-        //// --- End LibAFL code ---
     }
+
+    //// --- Begin LibAFL code ---
+    ioc->internal_allocation = capacity > 0;
+    //// --- End LibAFL code ---
 
     return ioc;
 }
@@ -75,6 +75,7 @@ static void qio_channel_buffer_finalize(Object *obj)
         g_free(ioc->data);
     }
 
+    ioc->data = NULL;
     //// --- End LibAFL code ---
     // g_free(ioc->data);
 
@@ -181,8 +182,8 @@ static int qio_channel_buffer_close(QIOChannel *ioc,
         g_free(bioc->data);
     }
 
-    //g_free(bioc->data);
     //// --- End LibAFL code ---
+    //g_free(bioc->data);
     bioc->data = NULL;
     bioc->capacity = bioc->usage = bioc->offset = 0;
 

--- a/libafl/syx-snapshot/device-save.c
+++ b/libafl/syx-snapshot/device-save.c
@@ -85,8 +85,6 @@ DeviceSaveState* device_save_kind(DeviceSnapshotKind kind, char** names) {
 }
 
 void device_restore_all(DeviceSaveState* dss) {
-    Error* err = NULL;
-
     assert(dss->save_buffer != NULL);
 
     QIOChannelBuffer* bioc = qio_channel_buffer_new_external(dss->save_buffer, QEMU_FILE_RAM_LIMIT, dss->save_buffer_size);
@@ -101,9 +99,7 @@ void device_restore_all(DeviceSaveState* dss) {
     
     libafl_restoring_devices = save_libafl_restoring_devices;
 
-    qio_channel_close(ioc, &err);
-    assert(!err);
-
+    object_unref(OBJECT(bioc));
     qemu_fclose(f);
 }
 

--- a/libafl/syx-snapshot/device-save.c
+++ b/libafl/syx-snapshot/device-save.c
@@ -85,6 +85,8 @@ DeviceSaveState* device_save_kind(DeviceSnapshotKind kind, char** names) {
 }
 
 void device_restore_all(DeviceSaveState* dss) {
+    Error* err = NULL;
+
     assert(dss->save_buffer != NULL);
 
     QIOChannelBuffer* bioc = qio_channel_buffer_new_external(dss->save_buffer, QEMU_FILE_RAM_LIMIT, dss->save_buffer_size);
@@ -99,7 +101,9 @@ void device_restore_all(DeviceSaveState* dss) {
     
     libafl_restoring_devices = save_libafl_restoring_devices;
 
-    object_unref(OBJECT(bioc));
+    qio_channel_close(ioc, &err);
+    assert(!err);
+
     qemu_fclose(f);
 }
 

--- a/libafl/syx-snapshot/device-save.c
+++ b/libafl/syx-snapshot/device-save.c
@@ -99,6 +99,7 @@ void device_restore_all(DeviceSaveState* dss) {
     
     libafl_restoring_devices = save_libafl_restoring_devices;
 
+    object_unref(OBJECT(bioc));
     qemu_fclose(f);
 }
 


### PR DESCRIPTION
Unset object to free memory space allocated (memory leak in fast snapshot implementation for libafl).
This PR fix the memory leak. 
An issue about it has been created on LibAFL