### PR TITLE
Early return from libafl edge generation if no exec hooks

### DIFF
--- a/include/libafl/exit.h
+++ b/include/libafl/exit.h
@@ -65,6 +65,9 @@ void libafl_exit_request_internal(CPUState* cpu, uint64_t pc,
                                   ShutdownCause cause, int signal);
 void libafl_exit_request_breakpoint(CPUState* cpu, target_ulong pc);
 void libafl_exit_request_sync_backdoor(CPUState* cpu, target_ulong pc);
+
+#ifndef CONFIG_USER_ONLY
 void libafl_exit_request_timeout(void);
+#endif
 
 struct libafl_exit_reason* libafl_get_exit_reason(void);

--- a/include/libafl/exit.h
+++ b/include/libafl/exit.h
@@ -21,15 +21,7 @@ enum libafl_exit_reason_kind {
     INTERNAL = 0,
     BREAKPOINT = 1,
     SYNC_EXIT = 2,
-};
-
-// A breakpoint has been triggered.
-struct libafl_exit_reason_breakpoint {
-    target_ulong addr;
-};
-
-// A synchronous exit has been triggered.
-struct libafl_exit_reason_sync_exit {
+    TIMEOUT = 3,
 };
 
 // QEMU exited on its own for some reason.
@@ -38,14 +30,26 @@ struct libafl_exit_reason_internal {
     int signal; // valid if cause == SHUTDOWN_CAUSE_HOST_SIGNAL
 };
 
+// A breakpoint has been triggered.
+struct libafl_exit_reason_breakpoint {
+    target_ulong addr;
+};
+
+// A synchronous exit has been triggered.
+struct libafl_exit_reason_sync_exit {};
+
+// A timeout occured and we were asked to exit on timeout
+struct libafl_exit_reason_timeout {};
+
 struct libafl_exit_reason {
     enum libafl_exit_reason_kind kind;
     CPUState* cpu; // CPU that triggered an exit.
     vaddr next_pc; // The PC that should be stored in the CPU when re-entering.
     union {
-        struct libafl_exit_reason_internal internal;
-        struct libafl_exit_reason_breakpoint breakpoint; // kind == BREAKPOINT
-        struct libafl_exit_reason_sync_exit sync_exit;   // kind == SYNC_EXIT
+        struct libafl_exit_reason_internal internal;        // kind == INTERNAL
+        struct libafl_exit_reason_breakpoint breakpoint;    // kind == BREAKPOINT
+        struct libafl_exit_reason_sync_exit sync_exit;      // kind == SYNC_EXIT
+        struct libafl_exit_reason_timeout timeout;          // kind == TIMEOUT
     } data;
 };
 
@@ -59,6 +63,8 @@ void libafl_sync_exit_cpu(void);
 
 void libafl_exit_request_internal(CPUState* cpu, uint64_t pc,
                                   ShutdownCause cause, int signal);
-void libafl_exit_request_sync_backdoor(CPUState* cpu, target_ulong pc);
 void libafl_exit_request_breakpoint(CPUState* cpu, target_ulong pc);
+void libafl_exit_request_sync_backdoor(CPUState* cpu, target_ulong pc);
+void libafl_exit_request_timeout(void);
+
 struct libafl_exit_reason* libafl_get_exit_reason(void);

--- a/libafl/exit.c
+++ b/libafl/exit.c
@@ -81,6 +81,7 @@ static void prepare_qemu_exit(CPUState* cpu, target_ulong next_pc)
     qemu_system_debug_request();
     cpu->stopped = true; // TODO check if still needed
 #endif
+
     // in usermode, this may be called from the syscall hook, thus already out
     // of the cpu_exec but still in the cpu_loop
     if (cpu->running) {
@@ -123,6 +124,15 @@ void libafl_exit_request_breakpoint(CPUState* cpu, target_ulong pc)
     last_exit_reason.data.breakpoint.addr = pc;
 
     prepare_qemu_exit(cpu, pc);
+}
+
+void libafl_exit_request_timeout(void)
+{
+    expected_exit = true;
+    last_exit_reason.kind = TIMEOUT;
+    last_exit_reason.cpu = current_cpu;
+
+    qemu_system_debug_request();
 }
 
 void libafl_qemu_trigger_breakpoint(CPUState* cpu)

--- a/libafl/exit.c
+++ b/libafl/exit.c
@@ -126,6 +126,7 @@ void libafl_exit_request_breakpoint(CPUState* cpu, target_ulong pc)
     prepare_qemu_exit(cpu, pc);
 }
 
+#ifndef CONFIG_USER_ONLY
 void libafl_exit_request_timeout(void)
 {
     expected_exit = true;
@@ -134,6 +135,7 @@ void libafl_exit_request_timeout(void)
 
     qemu_system_debug_request();
 }
+#endif
 
 void libafl_qemu_trigger_breakpoint(CPUState* cpu)
 {

--- a/libafl/hooks/tcg/block.c
+++ b/libafl/hooks/tcg/block.c
@@ -71,8 +71,11 @@ void libafl_qemu_hook_block_run(target_ulong pc)
 
     while (hook) {
         uint64_t cur_id = 0;
-        if (hook->gen)
+
+        if (hook->gen) {
             cur_id = hook->gen(hook->data, pc);
+        }
+
         if (cur_id != (uint64_t)-1 && hook->helper_info.func) {
             TCGv_i64 tmp0 = tcg_constant_i64(hook->data);
             TCGv_i64 tmp1 = tcg_constant_i64(cur_id);
@@ -81,9 +84,11 @@ void libafl_qemu_hook_block_run(target_ulong pc)
             tcg_temp_free_i64(tmp0);
             tcg_temp_free_i64(tmp1);
         }
+
         if (cur_id != (uint64_t)-1 && hook->jit) {
             hook->jit(hook->data, cur_id);
         }
+
         hook = hook->next;
     }
 }

--- a/libafl/hooks/tcg/edge.c
+++ b/libafl/hooks/tcg/edge.c
@@ -56,15 +56,22 @@ bool libafl_qemu_hook_edge_gen(target_ulong src_block, target_ulong dst_block)
 {
     struct libafl_edge_hook* hook = libafl_edge_hooks;
     bool no_exec_hook = true;
+
     while (hook) {
         hook->cur_id = 0;
-        if (hook->gen)
+
+        if (hook->gen) {
             hook->cur_id = hook->gen(hook->data, src_block, dst_block);
+        }
+
         if (hook->cur_id != (uint64_t)-1 &&
-            (hook->helper_info.func || hook->jit))
+            (hook->helper_info.func || hook->jit)) {
             no_exec_hook = false;
+        }
+
         hook = hook->next;
     }
+
     return no_exec_hook;
 }
 

--- a/libafl/syx-snapshot/syx-snapshot.c
+++ b/libafl/syx-snapshot/syx-snapshot.c
@@ -713,8 +713,8 @@ SyxSnapshotCheckResult syx_snapshot_check(SyxSnapshot* ref_snapshot)
 void syx_snapshot_root_restore(SyxSnapshot* snapshot)
 {
     // health check.
-    CPUState* cpu;
-    CPU_FOREACH(cpu) { assert(cpu->stopped); }
+    // CPUState* cpu;
+    // CPU_FOREACH(cpu) { assert(cpu->stopped); }
 
     bool must_unlock_bql = false;
 

--- a/subprojects/libvduse/meson.build
+++ b/subprojects/libvduse/meson.build
@@ -8,13 +8,18 @@ add_project_arguments(cc.get_supported_arguments('-Wsign-compare',
                                                  '-Wstrict-aliasing'),
                       native: false, language: 'c')
 
+#### --- Begin LibAFL code ---
 keyval = import('keyval')
 config_host = keyval.load(meson.global_build_root() / 'config-host.mak')
+#### --- End LibAFL code ---
 
 libvduse = static_library('vduse',
                           files('libvduse.c'),
                           c_args: '-D_GNU_SOURCE',
-                          pic: 'AS_SHARED_LIB' in config_host)
+#### --- Begin LibAFL code ---
+                          pic: 'AS_SHARED_LIB' in config_host
+#### --- End LibAFL code ---
+)
 
 libvduse_dep = declare_dependency(link_with: libvduse,
                                   include_directories: include_directories('.'))


### PR DESCRIPTION
there is a bug in the edge generation for systemmode.
this does not fix it atm, just does not trigger the bug if no exec hook is set up for edges.

also adds a clean exit for timeout.