### PR TITLE
Fix RPATH regex for Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/qemu_libafl_bridge/Cargo.lock
-/qemu_libafl_bridge/target/
 /GNUmakefile
 /build/
 /.cache/
@@ -22,3 +20,8 @@ GTAGS
 *.swp
 *.patch
 *.gcov
+
+# --- Begin LibAFL code ---
+/.idea
+/compile_commands.json
+# --- End LibAFL code ---

--- a/linker_interceptor.py
+++ b/linker_interceptor.py
@@ -40,6 +40,8 @@ def fix_compile_commands():
     with open("compile_commands.json", 'w') as f:
         f.write(res)
 
+    os.symlink("build/compile_commands.json", "../compile_commands.json")
+
 def process_args(args):
     global out_args, shareds, search, is_linking_qemu
     prev_o = False

--- a/linker_interceptor.py
+++ b/linker_interceptor.py
@@ -40,7 +40,8 @@ def fix_compile_commands():
     with open("compile_commands.json", 'w') as f:
         f.write(res)
 
-    os.symlink("build/compile_commands.json", "../compile_commands.json")
+    if not os.path.isfile("../compile_commands.json"):
+        os.symlink("build/compile_commands.json", "../compile_commands.json")
 
 def process_args(args):
     global out_args, shareds, search, is_linking_qemu

--- a/linker_interceptor.py
+++ b/linker_interceptor.py
@@ -24,7 +24,7 @@ rpath = []
 is_linking_qemu = False
 
 shared_library_pattern = r"^[^-].*/lib(.*)\.so(\.[0-9].*)?(?!rsp)$"
-rpath_pattern = r"^'.*,-rpath,(.*)'$"
+rpath_pattern = r".*,-rpath,(.*)'?.*"
 rpath_link_pattern = r"^.*,-rpath-link,(.*)$"
 
 linker_interceptor_pattern = r"(\": \")(.*linker_interceptor.py)( )"


### PR DESCRIPTION
for some reason the string format changes between distributions, it should work on ubuntu now