### PR TITLE
Cow cache snapshot rewriting

### DIFF
--- a/include/block/block-common.h
+++ b/include/block/block-common.h
@@ -226,6 +226,7 @@ typedef enum {
                                      writes in a snapshot */
 #define BDRV_O_TEMPORARY   0x0010 /* delete the file after use */
 #define BDRV_O_NOCACHE     0x0020 /* do not use the host page cache */
+#define BDRV_O_NOSYX       0x0040
 #define BDRV_O_NATIVE_AIO  0x0080 /* use native AIO instead of the
                                      thread pool */
 #define BDRV_O_NO_BACKING  0x0100 /* don't open the backing file */

--- a/include/libafl/exit.h
+++ b/include/libafl/exit.h
@@ -36,20 +36,22 @@ struct libafl_exit_reason_breakpoint {
 };
 
 // A synchronous exit has been triggered.
-struct libafl_exit_reason_sync_exit {};
+struct libafl_exit_reason_sync_exit {
+};
 
 // A timeout occured and we were asked to exit on timeout
-struct libafl_exit_reason_timeout {};
+struct libafl_exit_reason_timeout {
+};
 
 struct libafl_exit_reason {
     enum libafl_exit_reason_kind kind;
     CPUState* cpu; // CPU that triggered an exit.
     vaddr next_pc; // The PC that should be stored in the CPU when re-entering.
     union {
-        struct libafl_exit_reason_internal internal;        // kind == INTERNAL
-        struct libafl_exit_reason_breakpoint breakpoint;    // kind == BREAKPOINT
-        struct libafl_exit_reason_sync_exit sync_exit;      // kind == SYNC_EXIT
-        struct libafl_exit_reason_timeout timeout;          // kind == TIMEOUT
+        struct libafl_exit_reason_internal internal;     // kind == INTERNAL
+        struct libafl_exit_reason_breakpoint breakpoint; // kind == BREAKPOINT
+        struct libafl_exit_reason_sync_exit sync_exit;   // kind == SYNC_EXIT
+        struct libafl_exit_reason_timeout timeout;       // kind == TIMEOUT
     } data;
 };
 

--- a/include/libafl/utils.h
+++ b/include/libafl/utils.h
@@ -1,3 +1,4 @@
 #pragma once
 
 uintptr_t libafl_qemu_host_page_size(void);
+void libafl_qemu_backtrace(void);

--- a/include/qemu/iov.h
+++ b/include/qemu/iov.h
@@ -237,7 +237,7 @@ size_t qemu_iovec_concat_iov(QEMUIOVector *dst,
 bool qemu_iovec_is_zero(QEMUIOVector *qiov, size_t qiov_offeset, size_t bytes);
 void qemu_iovec_destroy(QEMUIOVector *qiov);
 void qemu_iovec_reset(QEMUIOVector *qiov);
-size_t qemu_iovec_to_buf(QEMUIOVector *qiov, size_t offset,
+size_t qemu_iovec_to_buf(const QEMUIOVector *qiov, size_t offset,
                          void *buf, size_t bytes);
 size_t qemu_iovec_from_buf(QEMUIOVector *qiov, size_t offset,
                            const void *buf, size_t bytes);

--- a/libafl/meson.build
+++ b/libafl/meson.build
@@ -1,4 +1,4 @@
-specific_ss.add(files(
+libafl_ss.add(files(
                     'cpu.c',
                     'exit.c',
                     'hook.c',
@@ -19,7 +19,7 @@ specific_ss.add(files(
                     'hooks/thread.c',
                 ))
 
-specific_ss.add(when : 'CONFIG_SOFTMMU', if_true : [files(
+libafl_ss.add(when : 'CONFIG_SOFTMMU', if_true : [files(
                                                         'system.c',
                                                         'qemu_snapshot.c',
                                                         'syx-snapshot/device-save.c',
@@ -28,7 +28,7 @@ specific_ss.add(when : 'CONFIG_SOFTMMU', if_true : [files(
                                                         'syx-snapshot/channel-buffer-writeback.c',
                                                     )])
 
-specific_ss.add(when : 'CONFIG_USER_ONLY', if_true : [files(
+libafl_ss.add(when : 'CONFIG_USER_ONLY', if_true : [files(
                                                           'user.c',
                                                           'hooks/syscall.c',
                                                     )])

--- a/libafl/syx-snapshot/syx-cow-cache.c
+++ b/libafl/syx-snapshot/syx-cow-cache.c
@@ -1,16 +1,105 @@
 #include "libafl/syx-snapshot/syx-cow-cache.h"
 
+#include "block/block_int-common.h"
 #include "sysemu/block-backend.h"
+#include "block/qdict.h"
+#include "block/block_int.h"
+#include "qemu/option.h"
+#include "qemu/cutils.h"
 
-#define IS_POWER_OF_TWO(x) ((x != 0) && ((x & (x - 1)) == 0))
+#include "libafl/syx-snapshot/syx-snapshot.h"
+
+#include <unistd.h>
+#include <dirent.h>
+
+#define IS_POWER_OF_TWO(x) (__builtin_popcountll(x) == 1)
+
+typedef struct BDRVSyxCowCacheState {
+    uint32_t id;
+    BlockDriverState* clone_bs;
+} BDRVSyxCowCacheState;
+
+// Checks that every opened file is opened in read-only mode.
+// It's a sanity check for the cow-cache mode, no file should ever be opened in
+// RW mode It's because the LibAFL QEMU process can open these files multiple
+// times in different processes to enable multi-core fuzzing. Another good
+// side-effect is the fact that disks will never be polluted by a fuzzing run,
+// the disk remains unchanged.
+void syx_cow_cache_check_files_ro(void)
+{
+    BlockDriverState* bs = NULL;
+    const BdrvChild* root = NULL;
+    DIR* d;
+    struct dirent* dir;
+    struct stat st;
+    char path[PATH_MAX] = {0};
+    char real_path[PATH_MAX] = {0};
+
+    d = opendir("/proc/self/fd");
+    assert(d);
+
+    BlockBackend* blk = NULL;
+    while ((blk = blk_all_next(blk)) != NULL) {
+        if ((root = blk_root(blk))) {
+            bs = root->bs;
+            assert(bs);
+
+            while ((dir = readdir(d)) != NULL) {
+                int fd = atoi(dir->d_name);
+                if (fd > 2) {
+                    assert(fstat(fd, &st) == 0);
+                    if (S_ISREG(st.st_mode)) {
+                        strcpy(path, "/proc/self/fd/");
+                        strcat(path, dir->d_name);
+                        ssize_t nb_bytes = readlink(path, real_path, PATH_MAX);
+                        assert(nb_bytes > 0);
+                        real_path[nb_bytes] = '\0';
+
+                        if (!strcmp(bs->filename, real_path)) {
+                            int res = fcntl(fd, F_GETFL);
+                            if ((res & O_ACCMODE) != O_RDONLY) {
+                                fprintf(
+                                    stderr,
+                                    "A file opened by QEMU is in RW mode: "
+                                    "%s.\nThis is a bug, please report it.\n",
+                                    bs->filename);
+                                abort();
+                            }
+                        }
+                    }
+                }
+            }
+
+            rewinddir(d);
+        }
+    }
+
+    closedir(d);
+}
 
 SyxCowCache* syx_cow_cache_new(void)
 {
-    SyxCowCache* cache = g_new0(SyxCowCache, 2);
+    SyxCowCache* cache = g_new0(SyxCowCache, 1);
 
     QTAILQ_INIT(&cache->layers);
 
     return cache;
+}
+
+static void syx_cow_cache_add_blk(SyxCowCache* scc)
+{
+    SyxCowCacheLayer* layer;
+    SyxCowCacheDevice dev;
+
+    layer = QTAILQ_FIRST(&scc->layers);
+    assert(layer);
+
+    dev.data = g_array_sized_new(false, false, layer->chunk_size,
+                                 INITIAL_NB_CHUNKS_PER_DEVICE);
+    dev.positions =
+        g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
+
+    g_array_append_val(layer->blks, dev);
 }
 
 static gchar* g_array_element_ptr(GArray* array, guint position)
@@ -19,241 +108,573 @@ static gchar* g_array_element_ptr(GArray* array, guint position)
     return array->data + position * g_array_get_element_size(array);
 }
 
-void syx_cow_cache_push_layer(SyxCowCache* scc, uint64_t chunk_size,
-                              uint64_t max_size)
+SyxCowCache* syx_cow_cache_push(SyxCowCache* scc, uint64_t chunk_size,
+                                uint64_t max_size)
 {
     SyxCowCacheLayer* new_layer = g_new0(SyxCowCacheLayer, 1);
+    SyxCowCache* new_scc = syx_cow_cache_new();
 
-    new_layer->cow_cache_devices =
-        g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
+    // Re-insert older layers
+    SyxCowCacheLayer* layer;
+    QTAILQ_FOREACH(layer, &scc->layers, next)
+    {
+        QTAILQ_INSERT_HEAD(&new_scc->layers, layer, next);
+    }
+
+    // Init new layer
+    new_layer->blks = g_array_new(false, false, sizeof(SyxCowCacheDevice));
     new_layer->chunk_size = chunk_size;
     new_layer->max_nb_chunks = max_size;
 
     assert(IS_POWER_OF_TWO(chunk_size));
     assert(!(max_size % chunk_size));
 
+    // Insert new layer at the top
     QTAILQ_INSERT_HEAD(&scc->layers, new_layer, next);
+
+    return new_scc;
 }
 
-void syx_cow_cache_pop_layer(SyxCowCache* scc)
-{
-    // TODO
-}
-
-static void flush_device_layer(gpointer _blk_name_hash, gpointer cache_device,
-                               gpointer _user_data)
-{
-    SyxCowCacheDevice* sccd = (SyxCowCacheDevice*)cache_device;
-
-    g_hash_table_remove_all(sccd->positions);
-    g_array_set_size(sccd->data, 0);
-}
+void syx_cow_cache_pop(SyxCowCache* scc) { assert(false && "TODO"); }
 
 void syx_cow_cache_flush_highest_layer(SyxCowCache* scc)
 {
-    SyxCowCacheLayer* highest_layer = QTAILQ_FIRST(&scc->layers);
+    SyxCowCacheLayer* layer = QTAILQ_FIRST(&scc->layers);
+    SyxCowCacheDevice* blk;
 
-    // highest_layer->cow_cache_devices
-    g_hash_table_foreach(highest_layer->cow_cache_devices, flush_device_layer,
-                         NULL);
+    for (int i = 0; i < layer->blks->len; ++i) {
+        blk = &g_array_index(layer->blks, SyxCowCacheDevice, i);
+
+        g_hash_table_remove_all(blk->positions);
+        g_array_set_size(blk->data, 0);
+    }
 }
 
-void syx_cow_cache_move(SyxCowCache* lhs, SyxCowCache** rhs)
+// Returns a pointer to chunk to read from, if it exists.
+// If nothing was found in the cache for the given offset, NULL is returned.
+static void* coroutine_fn get_read_chunk(SyxCowCacheDevice* sccd, int64_t aligned_offset)
 {
-    lhs->layers = (*rhs)->layers;
-    g_free(*rhs);
-    *rhs = NULL;
-}
-
-static bool read_chunk_from_cache_layer_device(SyxCowCacheDevice* sccd,
-                                               QEMUIOVector* qiov,
-                                               size_t qiov_offset,
-                                               uint64_t blk_offset)
-{
+    const int64_t chunk_size = g_array_get_element_size(sccd->data);
+    assert(QEMU_IS_ALIGNED(aligned_offset, chunk_size));
     gpointer data_position = NULL;
-    bool found = g_hash_table_lookup_extended(
-        sccd->positions, GUINT_TO_POINTER(blk_offset), NULL, &data_position);
 
-    // cache hit
+    bool found = g_hash_table_lookup_extended(sccd->positions,
+                                              GUINT_TO_POINTER(aligned_offset),
+                                              NULL, &data_position);
+
     if (found) {
-        void* data_position_ptr =
-            g_array_element_ptr(sccd->data, GPOINTER_TO_UINT(data_position));
-        assert(qemu_iovec_from_buf(qiov, qiov_offset, data_position_ptr,
-                                   g_array_get_element_size(sccd->data)) ==
-               g_array_get_element_size(sccd->data));
+        return g_array_element_ptr(sccd->data, GPOINTER_TO_UINT(data_position));
     }
 
-    return found;
+    return NULL;
 }
 
-// len must be smaller than nb bytes to next aligned to chunk of blk_offset.
-// static void write_to_cache_layer_device_unaligned(SyxCowCacheDevice* sccd,
-// QEMUIOVector* qiov, size_t qiov_offset, uint64_t blk_offset, uint64_t len)
-// {
-//     const uint64_t chunk_size = g_array_get_element_size(sccd->data);
-//
-//     assert(ROUND_UP(blk_offset, chunk_size) - blk_offset <= len);
-//     assert(IS_POWER_OF_TWO(chunk_size));
-//
-//     uint64_t blk_offset_aligned = ROUND_DOWN(blk_offset, chunk_size);
-//
-//     gpointer data_position = NULL;
-//     bool found = g_hash_table_lookup_extended(sccd->positions,
-//     GUINT_TO_POINTER(blk_offset_aligned), NULL, &data_position);
-//
-//     if (!found) {
-//         data_position = GUINT_TO_POINTER(sccd->data->len);
-//         sccd->data = g_array_set_size(sccd->data, sccd->data->len + 1);
-//         g_hash_table_insert(sccd->positions, GUINT_TO_POINTER(blk_offset),
-//         data_position);
-//     }
-//
-//     void* data_position_ptr = g_array_element_ptr(sccd->data,
-//     GPOINTER_TO_UINT(data_position));
-//
-//     assert(qemu_iovec_to_buf(qiov, qiov_offset, data_position_ptr,
-//     g_array_get_element_size(sccd->data)) ==
-//            g_array_get_element_size(sccd->data));
-// }
-
-// cache layer is allocated and all the basic checks are already done.
-static void write_chunk_to_cache_layer_device(SyxCowCacheDevice* sccd,
-                                              QEMUIOVector* qiov,
-                                              size_t qiov_offset,
-                                              uint64_t blk_offset)
+// returns a pointer to write the chunk to.
+// if it does not exist and child is non-NULL, it is prefilled with child data.
+// in other words, it is guaranteed to be valid to write to the pointer with
+// chunk_size bytes child should be NULL iif it is planned to fully fill the
+// chunk after the call.
+static void* coroutine_fn reserve_write_chunk(SyxCowCacheDevice* sccd, BdrvChild* child,
+                                 int64_t aligned_offset)
 {
-    const uint64_t chunk_size = g_array_get_element_size(sccd->data);
-
+    const int64_t chunk_size = g_array_get_element_size(sccd->data);
+    assert(QEMU_IS_ALIGNED(aligned_offset, chunk_size));
     gpointer data_position = NULL;
-    bool found = g_hash_table_lookup_extended(
-        sccd->positions, GUINT_TO_POINTER(blk_offset), NULL, &data_position);
+
+    bool found = g_hash_table_lookup_extended(sccd->positions,
+                                              GUINT_TO_POINTER(aligned_offset),
+                                              NULL, &data_position);
 
     if (!found) {
+        printf("\t\tAddr 0x%lx: not found\n", aligned_offset);
         data_position = GUINT_TO_POINTER(sccd->data->len);
         sccd->data = g_array_set_size(sccd->data, sccd->data->len + 1);
-        g_hash_table_insert(sccd->positions, GUINT_TO_POINTER(blk_offset),
+        g_hash_table_insert(sccd->positions, GUINT_TO_POINTER(aligned_offset),
                             data_position);
+
+        if (child) {
+            bdrv_co_pread(child, aligned_offset, chunk_size, data_position, 0);
+        }
     }
 
-    void* data_position_ptr =
-        g_array_element_ptr(sccd->data, GPOINTER_TO_UINT(data_position));
-
-    assert(qemu_iovec_to_buf(qiov, qiov_offset, data_position_ptr,
-                             chunk_size) == chunk_size);
+    return g_array_element_ptr(sccd->data, GPOINTER_TO_UINT(data_position));
 }
 
-static bool read_chunk_from_cache_layer(SyxCowCacheLayer* sccl,
-                                        BlockBackend* blk, QEMUIOVector* qiov,
-                                        size_t qiov_offset, uint64_t blk_offset)
+static void coroutine_fn write_chunk_to_cache_layer_device(SyxCowCacheDevice* sccd,
+                                               const QEMUIOVector* qiov,
+                                               BdrvChild* child,
+                                               const int64_t offset, const int64_t bytes,
+                                               const int64_t chunk_size)
 {
-    assert(!(qiov->size % sccl->chunk_size));
+    int64_t size_written = 0;
+    int64_t size_to_write;
+    void* data_position;
+    int64_t offset_begin_aligned, offset_begin_remainder, offset_end_aligned,
+        offset_end_remainder, offset_aligned_size, nb_middle_chunks;
 
-    SyxCowCacheDevice* cache_entry = g_hash_table_lookup(
-        sccl->cow_cache_devices, GINT_TO_POINTER(blk_name_hash(blk)));
+    // chunk size should be a power of 2
+    assert(IS_POWER_OF_TWO(chunk_size));
 
-    // return early if nothing is registered
-    if (!cache_entry) {
-        return false;
+    offset_begin_aligned = ROUND_DOWN(offset, chunk_size);
+    offset_begin_remainder = offset % chunk_size;
+
+    // number of chunks that can be written without alignment issues
+    nb_middle_chunks =
+        (ROUND_DOWN(offset + bytes, chunk_size) - ROUND_UP(offset, chunk_size)) / chunk_size;
+
+    offset_end_aligned = ROUND_DOWN(offset + bytes, chunk_size);
+    offset_end_remainder = (offset + bytes) % chunk_size;
+
+    // total size effectively reserved in the cache buffer
+    offset_aligned_size =
+        ROUND_UP(offset + bytes, chunk_size) - offset_begin_aligned;
+
+    assert((offset_aligned_size % chunk_size) ==
+           0); // aligned size should be... aligned
+
+    // Handle unaligned start
+    if (offset_begin_remainder) {
+        size_to_write =
+            MIN((offset_begin_aligned + chunk_size) - offset, bytes);
+
+        data_position =
+            reserve_write_chunk(sccd, child, offset_begin_aligned);
+
+        printf("\t[unaligned begin] Chunk write @addr 0x%lx\n", offset_begin_aligned);
+
+        qemu_iovec_to_buf(qiov, size_written,
+                          data_position + offset_begin_remainder,
+                          size_to_write);
+
+        size_written += size_to_write;
+
+        if (size_written == bytes) {
+            goto end;
+        }
     }
 
+    // write every chunk until (potentially) unaligned end.
+    for (int64_t i = 0; i < nb_middle_chunks; ++i) {
+        printf("\tChunk write @addr 0x%lx\n", offset + size_written);
+
+        // get cache pointer, either fresh of already allocated
+        data_position =
+            reserve_write_chunk(sccd, NULL, offset + size_written);
+
+        // overwrite cache with full chunk
+        assert(size_written <= qiov->size);
+        qemu_iovec_to_buf(qiov, size_written, data_position, chunk_size);
+
+        // Update size_written
+        size_written += chunk_size;
+    }
+
+    // Handle unaligned end
+    if (offset_end_remainder) {
+        size_to_write = bytes - size_written;
+
+        printf("\t[unaligned end] Chunk write @addr 0x%lx (size %ld)\n", offset_end_aligned, size_to_write);
+
+        data_position =
+            reserve_write_chunk(sccd, child, offset_end_aligned);
+
+        printf("\t[unaligned end] Writting %ld bytes to data_position (offset %ld)...\n", size_to_write, size_written);
+        qemu_iovec_to_buf(qiov, size_written, data_position, size_to_write);
+
+        size_written += size_to_write;
+    }
+
+end:
+    assert(size_written == bytes);
+}
+
+
+static void coroutine_fn read_chunk_from_cache_layer_device(SyxCowCacheDevice* sccd,
+                                               QEMUIOVector* qiov,
+                                               const int64_t offset, const int64_t bytes,
+                                               const uint64_t chunk_size)
+{
+    printf("\t\tread chunk (chunk size: 0x%lx)\n", chunk_size);
+    int64_t size_read = 0;
+    int64_t size_to_read;
+    void* data_position;
+    int64_t offset_begin_aligned, offset_begin_remainder, offset_end_aligned,
+        offset_end_remainder, offset_aligned_size, nb_middle_chunks;
+
+    // chunk size should be a power of 2
+    assert(IS_POWER_OF_TWO(chunk_size));
+
+    offset_begin_aligned = ROUND_DOWN(offset, chunk_size);
+    offset_begin_remainder = offset % chunk_size;
+
+    // number of chunks that can be read without alignment issues
+    nb_middle_chunks =
+        (ROUND_DOWN(offset + bytes, chunk_size) - ROUND_UP(offset, chunk_size)) / chunk_size;
+
+    offset_end_aligned = ROUND_DOWN(offset + bytes, chunk_size);
+    offset_end_remainder = (offset + bytes) % chunk_size;
+
+    // total size effectively reserved in the cache buffer
+    offset_aligned_size =
+        ROUND_UP(offset + bytes, chunk_size) - offset_begin_aligned;
+
+    assert((offset_aligned_size % chunk_size) == 0); // aligned size should be... aligned
+
+    // Handle unaligned start
+    printf("A\n");
+    if (offset_begin_remainder) {
+        size_to_read =
+            MIN((offset_begin_aligned + chunk_size) - offset, bytes);
+
+        printf("\t[unaligned begin] Read chunk @addr 0x%lx (size %ld)\n", offset_end_aligned, size_to_read);
+
+        data_position =
+            get_read_chunk(sccd, offset_begin_aligned);
+
+        if (data_position) {
+            printf("[read] cache hit!\n");
+            qemu_iovec_from_buf(qiov, size_read,
+                              data_position + offset_begin_remainder,
+                              size_to_read);
+        }
+
+        size_read += size_to_read;
+
+        if (size_read == bytes) {
+            return;
+        }
+    }
+
+    printf("B\n");
+    // write every chunk until (potentially) unaligned end.
+    for (int64_t i = 0; i < nb_middle_chunks; ++i) {
+        data_position =
+            get_read_chunk(sccd, offset + size_read);
+
+        printf("\tRead chunk @addr 0x%lx (size %ld)\n", offset + size_read, chunk_size);
+
+        // Cache hit, we must update the qiov
+        if (data_position) {
+            // printf("cache hit!\n");
+            qemu_iovec_from_buf(qiov, size_read,
+                              data_position,
+                              chunk_size);
+        }
+
+        size_read += chunk_size;
+    }
+
+    printf("C. offset_end_remainder: %ld. offset + bytes = %ld\n", offset_end_remainder, offset + bytes);
+    // Handle unaligned end
+    if (offset_end_remainder) {
+        printf("READ REMINDER....\n");
+        size_to_read = bytes - size_read;
+        assert(size_to_read == offset_end_remainder);
+
+        printf("\tRead chunk @addr 0x%lx (size %ld)\n", offset_end_aligned, chunk_size);
+
+        data_position =
+            get_read_chunk(sccd, offset_end_aligned);
+
+        // Cache hit, we must update the qiov
+        if (data_position) {
+            printf("cache hit!\n");
+            qemu_iovec_from_buf(qiov, size_read,
+                              data_position,
+                              size_to_read);
+        }
+
+        size_read += size_to_read;
+    }
+
+    printf("D\n");
+    assert(size_read == bytes);
+}
+
+static void coroutine_fn write_chunk_to_cache_layer(SyxCowCacheLayer* sccl, BdrvChild* child, const uint32_t id,
+                                        const QEMUIOVector* qiov, const int64_t offset,
+                                        const int64_t bytes)
+{
+    assert(id < sccl->blks->len);
+    SyxCowCacheDevice* cache_entry =
+        &g_array_index(sccl->blks, SyxCowCacheDevice, id);
+    assert(cache_entry && cache_entry->data);
+
+    // write qiov to cached pages in current layer.
+    write_chunk_to_cache_layer_device(cache_entry, qiov, child, offset, bytes,
+                                       sccl->chunk_size);
+}
+
+static void coroutine_fn read_chunk_from_cache_layer(SyxCowCacheLayer* sccl, const uint32_t id,
+                                        QEMUIOVector* qiov, const int64_t offset,
+                                        const int64_t bytes)
+{
+    assert(id < sccl->blks->len);
+    SyxCowCacheDevice* cache_entry =
+        &g_array_index(sccl->blks, SyxCowCacheDevice, id);
     assert(cache_entry && cache_entry->data);
 
     // try to read cached pages in current layer if something is registered.
-    return read_chunk_from_cache_layer_device(cache_entry, qiov, qiov_offset,
-                                              blk_offset);
+    read_chunk_from_cache_layer_device(cache_entry, qiov, offset, bytes,
+                                       sccl->chunk_size);
 }
 
-// Returns false if could not write to current layer.
-static bool write_to_cache_layer(SyxCowCacheLayer* sccl, BlockBackend* blk,
-                                 int64_t offset, int64_t bytes,
-                                 QEMUIOVector* qiov)
+
+static int syx_cow_cache_do_preadv(BlockDriverState* bs, int64_t offset, int64_t bytes,
+                        QEMUIOVector* qiov, BdrvRequestFlags flags)
 {
-    if (qiov->size % sccl->chunk_size) {
-        // todo: determine if it is worth developing an unaligned access
-        // version.
-        printf("error: 0x%zx %% 0x%lx == 0x%lx\n", qiov->size, sccl->chunk_size,
-               qiov->size % sccl->chunk_size);
-        exit(1);
+    BDRVSyxCowCacheState* s = bs->opaque;
+    SyxCowCache* scc = syx_snapshot_current_scc();
+    SyxCowCacheLayer* layer = QTAILQ_FIRST(&scc->layers);
+    size_t qiov_sz;
+
+    printf("[%d] Read @addr 0x%lx -> 0x%lx\n", s->id, offset, offset + bytes);
+    for (int64_t i = ROUND_DOWN(offset, layer->chunk_size); i < ROUND_UP(offset + bytes, layer->chunk_size); i += layer->chunk_size) {
+        printf("[%d]\tReading @addr 0x%lx\n", s->id, i);
     }
 
-    SyxCowCacheDevice* cache_entry = g_hash_table_lookup(
-        sccl->cow_cache_devices, GINT_TO_POINTER(blk_name_hash(blk)));
 
-    if (unlikely(!cache_entry)) {
-        cache_entry = g_new0(SyxCowCacheDevice, 1);
-        cache_entry->data = g_array_sized_new(false, false, sccl->chunk_size,
-                                              INITIAL_NB_CHUNKS_PER_DEVICE);
-        cache_entry->positions =
-            g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, NULL);
-        g_hash_table_insert(sccl->cow_cache_devices,
-                            GINT_TO_POINTER(blk_name_hash(blk)), cache_entry);
-    }
+    qiov_sz = iov_size(qiov->iov, qiov->niov);
+    assert(qiov_sz == qiov->size);
 
-    assert(cache_entry && cache_entry->data);
-
-    if (cache_entry->data->len + (qiov->size / sccl->chunk_size) >
-        sccl->max_nb_chunks) {
-        return false;
-    }
-
-    // write cached page
-    uint64_t blk_offset = offset;
-    size_t qiov_offset = 0;
-    for (; qiov_offset < qiov->size;
-         blk_offset += sccl->chunk_size, qiov_offset += sccl->chunk_size) {
-        write_chunk_to_cache_layer_device(cache_entry, qiov, qiov_offset,
-                                          blk_offset);
-    }
-
-    return true;
-}
-
-void syx_cow_cache_read_entry(SyxCowCache* scc, BlockBackend* blk,
-                              int64_t offset, int64_t bytes, QEMUIOVector* qiov,
-                              size_t _qiov_offset, BdrvRequestFlags flags)
-{
-    SyxCowCacheLayer* layer;
-    uint64_t blk_offset = offset;
-    size_t qiov_offset = 0;
-    uint64_t chunk_size = 0;
-
-    // printf("[%s] Read 0x%zx bytes @addr %lx\n", blk_name(blk), qiov->size,
-    // offset);
+    assert(scc);
 
     // First read the backing block device normally.
-    assert(blk_co_preadv(blk, offset, bytes, qiov, flags) >= 0);
+    bdrv_co_preadv(bs->file, offset, bytes, qiov, flags);
 
-    // Then fix the chunks that have been read from before.
-    if (!QTAILQ_EMPTY(&scc->layers)) {
-        for (; qiov_offset < qiov->size;
-             blk_offset += chunk_size, qiov_offset += chunk_size) {
-            QTAILQ_FOREACH(layer, &scc->layers, next)
-            {
-                chunk_size = layer->chunk_size;
-                if (read_chunk_from_cache_layer(layer, blk, qiov, qiov_offset,
-                                                blk_offset)) {
-                    break;
-                }
+    // Then fix the result with the chunks that have been written before.
+    // Start from the oldest layer, and go towards most recent layers
+    // use the real nb of bytes read, it could be lower than bytes with some
+    // blkdevs.
+    // A better strategy could be to go from top to bottom, and only read once for each sector. It is not
+    // so easy though, since unaligned start / end would require special treatment. For "full" chunks, this works.
+    QTAILQ_FOREACH_REVERSE(layer, &scc->layers, next)
+    {
+        read_chunk_from_cache_layer(layer, s->id, qiov, offset, bytes);
+    }
+
+    return bytes;
+}
+
+// ----- QEMU plug -----
+// TODO: cleanup, move in another directory
+
+static int syx_cow_cache_open(BlockDriverState* bs, QDict* options, int _flags,
+                              Error** errp)
+{
+    BDRVSyxCowCacheState* state = bs->opaque;
+    SyxCowCache* current_cache = syx_snapshot_current_scc();
+    char tmp[32];
+
+    static int ctr = 0;
+    state->id = ctr++;
+
+    assert(current_cache);
+    syx_cow_cache_add_blk(current_cache);
+
+    // Open child bdrv (files only are supported atm)
+    int ret = bdrv_open_file_child(NULL, options, "file", bs, errp);
+    if (ret < 0) {
+        return ret;
+    }
+
+    assert(bs->file);
+    assert(!strcmp(bs->file->bs->drv->format_name, "file"));
+    assert(sizeof(tmp) == sizeof(bs->node_name));
+
+    // exchange node names so that future references to the file falls back to
+    // our hook
+    pstrcpy(tmp, sizeof(bs->node_name), bs->node_name);
+    pstrcpy(bs->node_name, sizeof(bs->node_name), bs->file->bs->node_name);
+    pstrcpy(bs->file->bs->node_name, sizeof(bs->node_name), tmp);
+
+    // child should never have 'write' or 'write_unchanged' permission
+    assert(!(bs->file->perm & (BLK_PERM_WRITE | BLK_PERM_WRITE_UNCHANGED)));
+
+    // Reuse file parameters
+    bs->total_sectors = bs->file->bs->total_sectors;
+    bs->supported_read_flags = bs->file->bs->supported_read_flags;
+    bs->supported_write_flags =
+        BDRV_REQ_WRITE_UNCHANGED |
+        (BDRV_REQ_FUA & bs->file->bs->supported_write_flags);
+    bs->supported_zero_flags =
+        BDRV_REQ_WRITE_UNCHANGED |
+        ((BDRV_REQ_FUA | BDRV_REQ_MAY_UNMAP | BDRV_REQ_NO_FALLBACK) &
+         bs->file->bs->supported_zero_flags);
+
+    printf("\t[%d] linked to %s\n", state->id, bs->file->bs->filename);
+
+    // debug, to remove
+    {
+        char clone_file[PATH_MAX + 32];
+        Error* err = NULL;
+        sprintf(clone_file, "%s.clone", bs->file->bs->filename);
+        QDict *clone_options = qdict_new();
+        qdict_put_str(clone_options, "driver", "file");
+        qdict_put_str(clone_options, "filename", clone_file);
+
+        BlockDriverState* clone = bdrv_open(NULL, NULL, clone_options, BDRV_O_RDWR | BDRV_O_NOSYX, &err);
+        if (clone == NULL) {
+            assert(false);
+        }
+        state->clone_bs = clone;
+    }
+
+    return 0;
+}
+
+static void syx_cow_cache_check_bs_equality(BlockDriverState* bs, int64_t offset, int64_t bytes, int64_t chunk_size) {
+    BDRVSyxCowCacheState* s = bs->opaque;
+    QEMUIOVector qiov_scc, qiov_clone;
+
+    char* buf_scc = malloc(bytes);
+    qemu_iovec_init_buf(&qiov_scc, buf_scc, bytes);
+
+    char* buf_clone = malloc(bytes);
+    qemu_iovec_init_buf(&qiov_clone, buf_clone, bytes);
+
+    printf("Comparison starts...\n");
+
+    // read scc
+    syx_cow_cache_do_preadv(bs, offset, bytes, &qiov_scc, 0);
+
+    // read clone
+    s->clone_bs->drv->bdrv_co_preadv(s->clone_bs, offset, bytes, &qiov_clone, 0);
+
+    // compare QIOVs
+    char* buf_scc_out = malloc(bytes);
+    qemu_iovec_to_buf(&qiov_scc, 0, buf_scc_out, bytes);
+
+    char* buf_clone_out = malloc(bytes);
+    qemu_iovec_to_buf(&qiov_clone, 0, buf_clone_out, bytes);
+
+    if (memcmp(buf_scc_out, buf_clone_out, bytes) != 0) {
+        for (int i = 0; i < bytes; ++i) {
+            if (buf_scc_out[i] != buf_clone_out[i]) {
+                printf("\t\tdifference on chunk 0x%lx\n", ROUND_DOWN(offset + i, chunk_size));
             }
         }
+
+        // assert(false && "Bug in the syx-cow-cache bdrv found.");
+        printf("Bug in the syx-cow-cache bdrv found.\n");
+        while (true) {
+            sleep(1);
+        }
     }
+
+    printf("Comparison successful.\n");
+
+    free(buf_scc);
+    free(buf_clone);
+    free(buf_scc_out);
+    free(buf_clone_out);
 }
 
-bool syx_cow_cache_write_entry(SyxCowCache* scc, BlockBackend* blk,
-                               int64_t offset, int64_t bytes,
-                               QEMUIOVector* qiov, size_t qiov_offset,
-                               BdrvRequestFlags flags)
+static int coroutine_fn GRAPH_RDLOCK
+syx_cow_cache_co_preadv(BlockDriverState* bs, int64_t offset, int64_t bytes,
+                        QEMUIOVector* qiov, BdrvRequestFlags flags)
 {
+    SyxCowCache* scc = syx_snapshot_current_scc();
+    SyxCowCacheLayer* layer = QTAILQ_FIRST(&scc->layers);
+
+    syx_cow_cache_check_bs_equality(bs, offset, bytes, layer->chunk_size);
+
+    syx_cow_cache_do_preadv(bs, offset, bytes, qiov, flags);
+
+    // debug, to remove...
+    syx_cow_cache_check_bs_equality(bs, offset, bytes, layer->chunk_size);
+
+    return bytes;
+}
+
+static int coroutine_fn GRAPH_RDLOCK
+syx_cow_cache_co_pwritev(BlockDriverState* bs, int64_t offset, int64_t bytes,
+                         QEMUIOVector* qiov, BdrvRequestFlags flags)
+{
+    BDRVSyxCowCacheState* s = bs->opaque;
+    SyxCowCache* scc = syx_snapshot_current_scc();
     SyxCowCacheLayer* layer;
 
-    // printf("[%s] Write 0x%zx bytes @addr %lx\n", blk_name(blk), qiov->size,
-    // offset);
-
     layer = QTAILQ_FIRST(&scc->layers);
-    if (layer) {
-        assert(write_to_cache_layer(layer, blk, offset, bytes, qiov));
-        return true;
-    } else {
-        return false;
+    assert(layer);
+
+    for (int64_t i = ROUND_DOWN(offset, layer->chunk_size); i < ROUND_UP(offset + bytes, layer->chunk_size); i += layer->chunk_size) {
+        printf("[%d]\tWriting chunk @ 0x%lx\n", s->id, i);
     }
+
+    syx_cow_cache_check_bs_equality(bs, offset, bytes, layer->chunk_size);
+
+    s->clone_bs->drv->bdrv_co_pwritev(s->clone_bs, offset, bytes, qiov, flags);
+
+    write_chunk_to_cache_layer(layer, bs->file, s->id, qiov, offset, bytes);
+
+    syx_cow_cache_check_bs_equality(bs, offset, bytes, layer->chunk_size);
+
+    return bytes;
 }
+
+static int coroutine_fn GRAPH_RDLOCK syx_cow_cache_co_pwrite_zeroes(
+    BlockDriverState* bs, int64_t offset, int64_t bytes, BdrvRequestFlags flags)
+{
+    printf("WRITE ZEROES\n");
+    abort();
+    return bdrv_co_pwrite_zeroes(bs->file, offset, bytes, flags);
+}
+
+static int coroutine_fn GRAPH_RDLOCK
+syx_cow_cache_co_flush(BlockDriverState* bs)
+{
+    if (!bs->file) {
+        return 0;
+    }
+
+    return bdrv_co_flush(bs->file->bs);
+}
+
+static int coroutine_fn GRAPH_RDLOCK
+syx_cow_cache_co_pdiscard(BlockDriverState* bs, int64_t offset, int64_t bytes)
+{
+    return bdrv_co_pdiscard(bs->file, offset, bytes);
+}
+
+static void GRAPH_RDLOCK
+syx_cow_cache_child_perm(BlockDriverState* bs, BdrvChild* c, BdrvChildRole role,
+                         BlockReopenQueue* reopen_queue, uint64_t perm,
+                         uint64_t shared, uint64_t* nperm, uint64_t* nshared)
+{
+    assert(role & BDRV_CHILD_FILTERED);
+
+    bdrv_default_perms(bs, c, role, reopen_queue, perm, shared, nperm, nshared);
+
+    // We do not need 'write' and 'write_unchanged' permissions, the child is
+    // read-only anyway.
+    // *nperm &= ~(BLK_PERM_WRITE | BLK_PERM_WRITE_UNCHANGED);
+}
+
+static BlockDriver bdrv_syx_cow_cache = {
+    .format_name = "syx-cow-cache",
+    .instance_size = sizeof(BDRVSyxCowCacheState),
+
+    .bdrv_open = syx_cow_cache_open,
+    // .bdrv_close                 = syx_cow_cache_close,
+
+    .bdrv_co_preadv = syx_cow_cache_co_preadv,
+    .bdrv_co_pwritev = syx_cow_cache_co_pwritev,
+    .bdrv_co_pwrite_zeroes = syx_cow_cache_co_pwrite_zeroes,
+    .bdrv_co_pdiscard = syx_cow_cache_co_pdiscard,
+    .bdrv_co_flush = syx_cow_cache_co_flush,
+
+    // .bdrv_co_preadv_snapshot       = syx_cow_cache_co_preadv_snapshot,
+    // .bdrv_co_pdiscard_snapshot     = syx_cow_cache_co_pdiscard_snapshot,
+    // .bdrv_co_snapshot_block_status = syx_cow_cache_co_snapshot_block_status,
+
+    // .bdrv_refresh_filename      = syx_cow_cache_refresh_filename,
+
+    .bdrv_child_perm = syx_cow_cache_child_perm,
+
+    .is_filter = true,
+};
+
+static void syx_cow_cache_init(void) { bdrv_register(&bdrv_syx_cow_cache); }
+
+block_init(syx_cow_cache_init);

--- a/libafl/utils.c
+++ b/libafl/utils.c
@@ -1,7 +1,28 @@
 #include "qemu/osdep.h"
 #include "libafl/utils.h"
+#include <execinfo.h>
+
+#define MAX_NB_ADDRESSES 32
 
 uintptr_t libafl_qemu_host_page_size(void)
 {
     return qemu_real_host_page_size();
+}
+
+void libafl_qemu_backtrace(void)
+{
+    void* addresses[MAX_NB_ADDRESSES] = {0};
+
+    int nb_addresses = backtrace(addresses, MAX_NB_ADDRESSES);
+    char** symbols = backtrace_symbols(addresses, nb_addresses);
+
+    for (int i = 0; i < nb_addresses; ++i) {
+        fprintf(stderr, "[%p] %s]\n", addresses[i], symbols[i]);
+    }
+
+    if (nb_addresses == MAX_NB_ADDRESSES) {
+        fprintf(stderr, "... and continues...\n");
+    }
+
+    free(symbols);
 }

--- a/meson.build
+++ b/meson.build
@@ -3433,6 +3433,9 @@ util_ss = ss.source_set()
 qtest_module_ss = ss.source_set()
 tcg_module_ss = ss.source_set()
 
+# libafl module
+libafl_ss = ss.source_set()
+
 modules = {}
 target_modules = {}
 hw_arch = {}
@@ -3930,9 +3933,22 @@ foreach target : target_dirs
   arch_srcs += target_specific.sources()
   arch_deps += target_specific.dependencies()
 
+  libafl_ss = libafl_ss.apply(config_target, strict: false)
+  liblibafl = static_library('libafl-' + target,
+                             sources: libafl_ss.sources() + genh,
+                             dependencies: arch_deps,
+                             objects: objects,
+                             include_directories: target_inc,
+                             c_args: c_args,
+                             build_by_default: false,
+                             name_suffix: 'fa',
+                             pic: 'AS_SHARED_LIB' in config_host)
+  libafl = declare_dependency(link_whole: [liblibafl],
+                              link_args: '@libafl.syms')
+
   lib = static_library('qemu-' + target,
                  sources: arch_srcs + genh,
-                 dependencies: arch_deps,
+                 dependencies: arch_deps + libafl,
                  objects: objects,
                  include_directories: target_inc,
                  c_args: c_args,

--- a/qapi/block-core.json
+++ b/qapi/block-core.json
@@ -3189,6 +3189,7 @@
   'data': [ 'blkdebug', 'blklogwrites', 'blkreplay', 'blkverify', 'bochs',
             'cloop', 'compress', 'copy-before-write', 'copy-on-read', 'dmg',
             'file', 'snapshot-access', 'ftp', 'ftps', 'gluster',
+            'syx-cow-cache',
             {'name': 'host_cdrom', 'if': 'HAVE_HOST_BLOCK_DEVICE' },
             {'name': 'host_device', 'if': 'HAVE_HOST_BLOCK_DEVICE' },
             'http', 'https',
@@ -3612,6 +3613,22 @@
             '*cache-clean-interval': 'int',
             '*encrypt': 'BlockdevQcow2Encryption',
             '*data-file': 'BlockdevRef' } }
+
+
+##
+# @BlockdevOptionsSyxCowCache:
+#
+# Driver specific block device options for Syx Cow Cache. It is intended
+# to be used as a wrapper around other devices transparently. This should
+# never be invoked directly by a user.
+#
+# Since: 9.0.2
+##
+{
+  'struct': 'BlockdevOptionsSyxCowCache',
+  'base': 'BlockdevOptionsGenericFormat',
+  'data': { }
+}
 
 ##
 # @SshHostKeyCheckMode:
@@ -4734,6 +4751,7 @@
                        'if': 'CONFIG_REPLICATION' },
       'snapshot-access': 'BlockdevOptionsGenericFormat',
       'ssh':        'BlockdevOptionsSsh',
+      'syx-cow-cache': 'BlockdevOptionsSyxCowCache',
       'throttle':   'BlockdevOptionsThrottle',
       'vdi':        'BlockdevOptionsGenericFormat',
       'vhdx':       'BlockdevOptionsGenericFormat',

--- a/system/vl.c
+++ b/system/vl.c
@@ -134,6 +134,8 @@
 #include "qemu/guest-random.h"
 #include "qemu/keyval.h"
 
+#include "libafl/syx-snapshot/syx-cow-cache.h"
+
 #define MAX_VIRTIO_CONSOLES 1
 
 typedef struct BlockdevOptionsQueueEntry {
@@ -3668,7 +3670,9 @@ void qemu_init(int argc, char **argv)
     qemu_disable_default_devices();
     qemu_setup_display();
     qemu_create_default_devices();
+    syx_cow_cache_check_files_ro();
     qemu_create_early_backends();
+    syx_cow_cache_check_files_ro();
 
     qemu_apply_legacy_machine_options(machine_opts_dict);
     qemu_apply_machine_options(machine_opts_dict);
@@ -3710,6 +3714,7 @@ void qemu_init(int argc, char **argv)
      * over memory-backend-file objects).
      */
     qemu_create_late_backends();
+    syx_cow_cache_check_files_ro();
     phase_advance(PHASE_LATE_BACKENDS_CREATED);
 
     /*

--- a/util/iov.c
+++ b/util/iov.c
@@ -481,7 +481,7 @@ void qemu_iovec_reset(QEMUIOVector *qiov)
     qiov->size = 0;
 }
 
-size_t qemu_iovec_to_buf(QEMUIOVector *qiov, size_t offset,
+size_t qemu_iovec_to_buf(const QEMUIOVector *qiov, size_t offset,
                          void *buf, size_t bytes)
 {
     return iov_to_buf(qiov->iov, qiov->niov, offset, buf, bytes);


### PR DESCRIPTION
new implementation for block device snapshot.
what's new:
- works for any block device (not only qcow2-backed stuff)
- makes sure backends are always open in read-only. it becomes possible to have multiple fuzzers using the same file even if it's opened in r/w by qemu
- works more smoothly for unaligned accesses 