### PR TITLE
Fix helper function calls & support for new x86 decoder

### DIFF
--- a/include/libafl/hook.h
+++ b/include/libafl/hook.h
@@ -56,6 +56,4 @@
 extern target_ulong libafl_gen_cur_pc;
 extern size_t libafl_qemu_hooks_num;
 
-void tcg_gen_callN(TCGHelperInfo* info, TCGTemp* ret, TCGTemp** args);
-
 void libafl_tcg_gen_asan(TCGTemp* addr, size_t size);

--- a/include/libafl/hooks/tcg/edge.h
+++ b/include/libafl/hooks/tcg/edge.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "qemu/osdep.h"
-
 #include "qapi/error.h"
 
 #include "exec/exec-all.h"

--- a/include/libafl/tcg.h
+++ b/include/libafl/tcg.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "qemu/osdep.h"
+#include "qapi/error.h"
+
+#include "tcg/tcg.h"
+#include "tcg/helper-info.h"
+
+void tcg_gen_callN(void *func, TCGHelperInfo *info,
+                          TCGTemp *ret, TCGTemp **args);

--- a/libafl/hooks/tcg/backdoor.c
+++ b/libafl/hooks/tcg/backdoor.c
@@ -1,3 +1,4 @@
+#include "libafl/tcg.h"
 #include "libafl/hooks/tcg/backdoor.h"
 
 struct libafl_backdoor_hook* libafl_backdoor_hooks;
@@ -40,7 +41,7 @@ void libafl_qemu_hook_backdoor_run(vaddr pc_next)
         TCGTemp* args[3] = {tcgv_i64_temp(tmp0), tcgv_ptr_temp(tcg_env),
                             tcgv_tl_temp(tmp2)};
 
-        tcg_gen_callN(&bhk->helper_info, NULL, args);
+        tcg_gen_callN(bhk->helper_info.func, &bhk->helper_info, NULL, args);
 
         bhk = bhk->next;
     }

--- a/libafl/hooks/tcg/block.c
+++ b/libafl/hooks/tcg/block.c
@@ -1,3 +1,4 @@
+#include "libafl/tcg.h"
 #include "libafl/hooks/tcg/block.h"
 
 struct libafl_block_hook* libafl_block_hooks;
@@ -80,7 +81,7 @@ void libafl_qemu_hook_block_run(target_ulong pc)
             TCGv_i64 tmp0 = tcg_constant_i64(hook->data);
             TCGv_i64 tmp1 = tcg_constant_i64(cur_id);
             TCGTemp* tmp2[2] = {tcgv_i64_temp(tmp0), tcgv_i64_temp(tmp1)};
-            tcg_gen_callN(&hook->helper_info, NULL, tmp2);
+            tcg_gen_callN(hook->helper_info.func, &hook->helper_info, NULL, tmp2);
             tcg_temp_free_i64(tmp0);
             tcg_temp_free_i64(tmp1);
         }

--- a/libafl/hooks/tcg/cmp.c
+++ b/libafl/hooks/tcg/cmp.c
@@ -1,3 +1,4 @@
+#include "libafl/tcg.h"
 #include "libafl/hooks/tcg/cmp.h"
 
 struct libafl_cmp_hook* libafl_cmp_hooks;
@@ -120,7 +121,7 @@ void libafl_gen_cmp(target_ulong pc, TCGv op0, TCGv op1, MemOp ot)
 #else
                                 tcgv_i64_temp(op0), tcgv_i64_temp(op1)};
 #endif
-            tcg_gen_callN(info, NULL, tmp2);
+            tcg_gen_callN(info->func, info, NULL, tmp2);
             tcg_temp_free_i64(tmp0);
             tcg_temp_free_i64(tmp1);
         }

--- a/libafl/hooks/tcg/edge.c
+++ b/libafl/hooks/tcg/edge.c
@@ -1,3 +1,4 @@
+#include "libafl/tcg.h"
 #include "libafl/hooks/tcg/edge.h"
 
 struct libafl_edge_hook* libafl_edge_hooks;
@@ -8,7 +9,8 @@ static TCGHelperInfo libafl_exec_edge_hook_info = {
     .name = "libafl_exec_edge_hook",
     .flags = dh_callflag(void),
     .typemask =
-        dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2)};
+        dh_typemask(void, 0) | dh_typemask(i64, 1) | dh_typemask(i64, 2)
+};
 
 GEN_REMOVE_HOOK(edge)
 
@@ -84,7 +86,7 @@ void libafl_qemu_hook_edge_run(void)
             TCGv_i64 tmp0 = tcg_constant_i64(hook->data);
             TCGv_i64 tmp1 = tcg_constant_i64(hook->cur_id);
             TCGTemp* tmp2[2] = {tcgv_i64_temp(tmp0), tcgv_i64_temp(tmp1)};
-            tcg_gen_callN(&hook->helper_info, NULL, tmp2);
+            tcg_gen_callN(hook->helper_info.func, &hook->helper_info, NULL, tmp2);
             tcg_temp_free_i64(tmp0);
             tcg_temp_free_i64(tmp1);
         }

--- a/libafl/hooks/tcg/instruction.c
+++ b/libafl/hooks/tcg/instruction.c
@@ -1,3 +1,4 @@
+#include "libafl/tcg.h"
 #include "libafl/hooks/tcg/instruction.h"
 
 #include "libafl/cpu.h"
@@ -124,7 +125,7 @@ void libafl_qemu_hook_instruction_run(vaddr pc_next)
         TCGTemp* tmp2[2] = {tcgv_i64_temp(tmp0), tcgv_i64_temp(tmp1)};
 #endif
         // tcg_gen_callN(hk->callback, NULL, 2, tmp2);
-        tcg_gen_callN(&hk->helper_info, NULL, tmp2);
+        tcg_gen_callN(hk->helper_info.func, &hk->helper_info, NULL, tmp2);
 #if TARGET_LONG_BITS == 32
         tcg_temp_free_i32(tmp1);
 #else

--- a/libafl/hooks/tcg/read_write.c
+++ b/libafl/hooks/tcg/read_write.c
@@ -1,3 +1,4 @@
+#include "libafl/tcg.h"
 #include "libafl/hooks/tcg/read_write.h"
 
 struct libafl_rw_hook* libafl_read_hooks;
@@ -201,7 +202,7 @@ static void libafl_gen_rw(TCGTemp* addr, MemOpIdx oi,
                 TCGv_i64 tmp1 = tcg_constant_i64(cur_id);
                 TCGTemp* tmp2[3] = {tcgv_i64_temp(tmp0), tcgv_i64_temp(tmp1),
                                     addr};
-                tcg_gen_callN(info, NULL, tmp2);
+                tcg_gen_callN(info->func, info, NULL, tmp2);
                 tcg_temp_free_i64(tmp0);
                 tcg_temp_free_i64(tmp1);
             } else if (hook->helper_infoN.func) {
@@ -215,7 +216,7 @@ static void libafl_gen_rw(TCGTemp* addr, MemOpIdx oi,
 #else
                                     tcgv_i64_temp(tmp2)};
 #endif
-                tcg_gen_callN(&hook->helper_infoN, NULL, tmp3);
+                tcg_gen_callN(hook->helper_infoN.func, &hook->helper_infoN, NULL, tmp3);
                 tcg_temp_free_i64(tmp0);
                 tcg_temp_free_i64(tmp1);
 #if TARGET_LONG_BITS == 32

--- a/target/i386/tcg/emit.c.inc
+++ b/target/i386/tcg/emit.c.inc
@@ -3848,6 +3848,13 @@ static void gen_SUB(DisasContext *s, X86DecodedInsn *decode)
         tcg_gen_sub_tl(s->T0, s->cc_srcT, s->T1);
     } else {
         tcg_gen_mov_tl(s->cc_srcT, s->T0);
+
+//// --- Begin LibAFL code ---
+
+        libafl_gen_cmp(s->pc, s->T0, s->T1, ot);
+
+//// --- End LibAFL code ---
+
         tcg_gen_sub_tl(s->T0, s->T0, s->T1);
     }
     prepare_update2_cc(decode, s, CC_OP_SUBB + ot);

--- a/target/i386/tcg/translate.c
+++ b/target/i386/tcg/translate.c
@@ -38,7 +38,7 @@
 
 //// --- Begin LibAFL code ---
 
-void libafl_gen_cmp(target_ulong pc, TCGv op0, TCGv op1, MemOp ot);
+#include "libafl/hooks/tcg/cmp.h"
 
 //// --- End LibAFL code ---
 
@@ -1234,6 +1234,13 @@ static void gen_cmps(DisasContext *s, MemOp ot)
     gen_op_ld_v(s, ot, s->T0, s->A0);
     tcg_gen_mov_tl(cpu_cc_src, s->T1);
     tcg_gen_mov_tl(s->cc_srcT, s->T0);
+
+//// --- Begin LibAFL code ---
+
+        libafl_gen_cmp(s->pc, s->T0, s->T1, ot);
+
+//// --- End LibAFL code ---
+
     tcg_gen_sub_tl(cpu_cc_dst, s->T0, s->T1);
     set_cc_op(s, CC_OP_SUBB + ot);
 

--- a/tcg/tcg.c
+++ b/tcg/tcg.c
@@ -60,6 +60,10 @@
 #include "user/guest-base.h"
 #endif
 
+//// --- Begin LibAFL code ---
+#include "libafl/tcg.h"
+//// --- End LibAFL code ---
+
 /* Forward declarations for functions declared in tcg-target.c.inc and
    used here. */
 static void tcg_target_init(TCGContext *s);
@@ -2240,13 +2244,9 @@ bool tcg_op_supported(TCGOpcode op)
 static TCGOp *tcg_op_alloc(TCGOpcode opc, unsigned nargs);
 
 //// --- Begin LibAFL code ---
-
-void tcg_gen_callN(void *func, TCGHelperInfo *info,
-                          TCGTemp *ret, TCGTemp **args);
-
+/* static */
 //// --- End LibAFL code ---
-
-/* static */ void tcg_gen_callN(void *func, TCGHelperInfo *info,
+void tcg_gen_callN(void *func, TCGHelperInfo *info,
                           TCGTemp *ret, TCGTemp **args)
 {
     TCGv_i64 extend_free[MAX_CALL_IARGS];


### PR DESCRIPTION
latest qemu update changed `tcg_gen_callN` signature