### PR TITLE
Add systemmode hw_breakpoint libafl set/remove fns

### DIFF
--- a/accel/kvm/kvm-accel-ops.c
+++ b/accel/kvm/kvm-accel-ops.c
@@ -61,7 +61,11 @@ static void *kvm_vcpu_thread_fn(void *arg)
         if (cpu_can_run(cpu)) {
             r = kvm_cpu_exec(cpu);
             if (r == EXCP_DEBUG) {
-                cpu_handle_guest_debug(cpu);
+//// --- Begin LibAFL code ---
+				cpu->stopped = true;
+				libafl_qemu_trigger_breakpoint(cpu);
+                // cpu_handle_guest_debug(cpu);
+//// --- End LibAFL code ---
             }
         }
         qemu_wait_io_event(cpu);

--- a/accel/kvm/kvm-accel-ops.c
+++ b/accel/kvm/kvm-accel-ops.c
@@ -62,9 +62,9 @@ static void *kvm_vcpu_thread_fn(void *arg)
             r = kvm_cpu_exec(cpu);
             if (r == EXCP_DEBUG) {
 //// --- Begin LibAFL code ---
+                // cpu_handle_guest_debug(cpu);
 				cpu->stopped = true;
 				libafl_qemu_trigger_breakpoint(cpu);
-                // cpu_handle_guest_debug(cpu);
 //// --- End LibAFL code ---
             }
         }

--- a/gdbstub/system.c
+++ b/gdbstub/system.c
@@ -33,6 +33,7 @@
 
 //// --- Begin LibAFL code ---
 #include "libafl/gdb.h"
+#include "gdbstub/enums.h"
 //// --- End LibAFL code ---
 
 /* System emulation specific state */
@@ -655,6 +656,12 @@ bool gdb_supports_guest_debug(void)
 int gdb_breakpoint_insert(CPUState *cs, int type, vaddr addr, vaddr len)
 {
     const AccelOpsClass *ops = cpus_get_accel();
+    //// --- Begin LibAFL code ---
+    // HW breakpoints are reserved for LibAFL
+    if (type == GDB_BREAKPOINT_HW) {
+        return -ENOSYS;
+    }
+    //// --- End LibAFL code ---
     if (ops->insert_breakpoint) {
         return ops->insert_breakpoint(cs, type, addr, len);
     }

--- a/include/libafl/system.h
+++ b/include/libafl/system.h
@@ -7,5 +7,6 @@
 
 int libafl_qemu_set_hw_breakpoint(vaddr addr);
 int libafl_qemu_remove_hw_breakpoint(vaddr addr);
+//static vaddr libafl_qemu_hw_breakpoints[4];
 
 void libafl_qemu_init(int argc, char** argv);

--- a/include/libafl/system.h
+++ b/include/libafl/system.h
@@ -7,6 +7,5 @@
 
 int libafl_qemu_set_hw_breakpoint(vaddr addr);
 int libafl_qemu_remove_hw_breakpoint(vaddr addr);
-//static vaddr libafl_qemu_hw_breakpoints[4];
 
 void libafl_qemu_init(int argc, char** argv);

--- a/include/libafl/system.h
+++ b/include/libafl/system.h
@@ -1,3 +1,11 @@
 #pragma once
 
+#include "hw/core/cpu.h"
+#include "gdbstub/enums.h"
+#include "sysemu/accel-ops.h"
+#include "sysemu/cpus.h"
+
+int libafl_qemu_set_hw_breakpoint(vaddr addr);
+int libafl_qemu_remove_hw_breakpoint(vaddr addr);
+
 void libafl_qemu_init(int argc, char** argv);

--- a/include/sysemu/cpus.h
+++ b/include/sysemu/cpus.h
@@ -3,6 +3,10 @@
 
 #include "sysemu/accel-ops.h"
 
+//// --- Begin LibAFL code ---
+//#include "libafl/exit.h"
+//// --- End LibAFL code ---
+
 /* register accel-specific operations */
 void cpus_register_accel(const AccelOpsClass *i);
 

--- a/include/sysemu/cpus.h
+++ b/include/sysemu/cpus.h
@@ -3,10 +3,6 @@
 
 #include "sysemu/accel-ops.h"
 
-//// --- Begin LibAFL code ---
-//#include "libafl/exit.h"
-//// --- End LibAFL code ---
-
 /* register accel-specific operations */
 void cpus_register_accel(const AccelOpsClass *i);
 

--- a/libafl/system.c
+++ b/libafl/system.c
@@ -23,18 +23,41 @@ int libafl_qemu_toggle_hw_breakpoint(vaddr addr, bool set) {
     const AccelOpsClass *ops = cpus_get_accel();
 
     CPUState* cs;
+//    int i = 0;
     int ret = 0;
+//    vaddr old_addr, new_addr;
 
     if (!ops->insert_breakpoint) {
         return -ENOSYS;
     }
 
+    // let's add/remove it on every CPU
     CPU_FOREACH(cs) {
         if (set) {
-            ret |= ops->insert_breakpoint(cs, type, addr, len);
+            ret = ops->insert_breakpoint(cs, type, addr, len);
         } else {
-            ret |= ops->remove_breakpoint(cs, type, addr, len);
+            ret = ops->remove_breakpoint(cs, type, addr, len);
+        }
+        if (ret != 0) {
+            return ret;
         }
     }
-    return ret;
+
+//    // update libafl hw breakpoint state libafl_qemu_hw_breakpoints
+//    if (set) {
+//		old_addr = 0;
+//        new_addr = addr;
+//    } else {
+//    	old_addr = addr;
+//        new_addr = 0;
+//    }
+//    while (libafl_qemu_hw_breakpoints[i] != old_addr && i < 4) {
+//        ++i;
+//    }
+//    if (i==4) {
+//    	return -EINVAL;
+//    }
+//    libafl_qemu_hw_breakpoints[i] = new_addr;
+
+    return 0;
 }

--- a/libafl/system.c
+++ b/libafl/system.c
@@ -3,4 +3,38 @@
 
 #include "libafl/system.h"
 
+int libafl_qemu_toggle_hw_breakpoint(vaddr addr, bool set);
+
 void libafl_qemu_init(int argc, char** argv) { qemu_init(argc, argv); }
+
+int libafl_qemu_set_hw_breakpoint(vaddr addr)
+{
+    return libafl_qemu_toggle_hw_breakpoint(addr, true);
+}
+
+int libafl_qemu_remove_hw_breakpoint(vaddr addr)
+{
+    return libafl_qemu_toggle_hw_breakpoint(addr, false);
+}
+
+int libafl_qemu_toggle_hw_breakpoint(vaddr addr, bool set) {
+    const int type = GDB_BREAKPOINT_HW;
+    const vaddr len = 1;
+    const AccelOpsClass *ops = cpus_get_accel();
+
+    CPUState* cs;
+    int ret = 0;
+
+    if (!ops->insert_breakpoint) {
+        return -ENOSYS;
+    }
+
+    CPU_FOREACH(cs) {
+        if (set) {
+            ret |= ops->insert_breakpoint(cs, type, addr, len);
+        } else {
+            ret |= ops->remove_breakpoint(cs, type, addr, len);
+        }
+    }
+    return ret;
+}

--- a/libafl/system.c
+++ b/libafl/system.c
@@ -23,15 +23,13 @@ int libafl_qemu_toggle_hw_breakpoint(vaddr addr, bool set) {
     const AccelOpsClass *ops = cpus_get_accel();
 
     CPUState* cs;
-//    int i = 0;
     int ret = 0;
-//    vaddr old_addr, new_addr;
 
     if (!ops->insert_breakpoint) {
         return -ENOSYS;
     }
 
-    // let's add/remove it on every CPU
+    // let's add/remove the breakpoint on every CPU
     CPU_FOREACH(cs) {
         if (set) {
             ret = ops->insert_breakpoint(cs, type, addr, len);
@@ -42,22 +40,6 @@ int libafl_qemu_toggle_hw_breakpoint(vaddr addr, bool set) {
             return ret;
         }
     }
-
-//    // update libafl hw breakpoint state libafl_qemu_hw_breakpoints
-//    if (set) {
-//		old_addr = 0;
-//        new_addr = addr;
-//    } else {
-//    	old_addr = addr;
-//        new_addr = 0;
-//    }
-//    while (libafl_qemu_hw_breakpoints[i] != old_addr && i < 4) {
-//        ++i;
-//    }
-//    if (i==4) {
-//    	return -EINVAL;
-//    }
-//    libafl_qemu_hw_breakpoints[i] = new_addr;
 
     return 0;
 }


### PR DESCRIPTION
reserve hw breakpoints for LibAFL, using them with GDB will return a graceful error. So far they are implemented only for kvm.