### PR TITLE
Companion patch for LibAFL #2776

### DIFF
--- a/include/libafl/user.h
+++ b/include/libafl/user.h
@@ -31,6 +31,7 @@ IntervalTreeNode* libafl_maps_next(IntervalTreeNode* pageflags_maps_node,
 uint64_t libafl_load_addr(void);
 struct image_info* libafl_get_image_info(void);
 
+uint64_t libafl_get_initial_brk(void);
 uint64_t libafl_get_brk(void);
 uint64_t libafl_set_brk(uint64_t new_brk);
 

--- a/libafl/user.c
+++ b/libafl/user.c
@@ -29,6 +29,8 @@ struct image_info* libafl_get_image_info(void) { return &libafl_image_info; }
 
 uint64_t libafl_get_brk(void) { return (uint64_t)target_brk; }
 
+uint64_t libafl_get_initial_brk(void) { return (uint64_t)initial_target_brk; }
+
 uint64_t libafl_set_brk(uint64_t new_brk)
 {
     uint64_t old_brk = (uint64_t)target_brk;


### PR DESCRIPTION
This add the `libafl_get_initial_brk` API to fix LibAFL #2776