### PR TITLE
physmem: allow cpu_memory_rw_debug to write to MMIO devices

### DIFF
--- a/system/physmem.c
+++ b/system/physmem.c
@@ -3589,12 +3589,13 @@ int cpu_memory_rw_debug(CPUState *cpu, vaddr addr,
         if (l > len)
             l = len;
         phys_addr += (addr & ~TARGET_PAGE_MASK);
-        if (is_write) {
-            res = address_space_write_rom(cpu->cpu_ases[asidx].as, phys_addr,
-                                          attrs, buf, l);
-        } else {
-            res = address_space_read(cpu->cpu_ases[asidx].as, phys_addr,
-                                     attrs, buf, l);
+        res = address_space_rw(cpu->cpu_ases[asidx].as, phys_addr,
+                                   attrs, buf, l, is_write);
+        if (res != MEMTX_OK && is_write) {
+            /* Fallback since it might be a ROM region*/
+            /* TODO verify that this works as expected*/
+            res = address_space_write_rom(cpu->cpu_ases[asidx].as,
+                                          phys_addr, attrs, buf, l);
         }
         if (res != MEMTX_OK) {
             return -1;


### PR DESCRIPTION
Resolves: https://gitlab.com/qemu-project/qemu/-/issues/213
Closes #95 