### PR TITLE
Fix build for latest version of glibc

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -364,6 +364,7 @@ _syscall3(int, sys_sched_getaffinity, pid_t, pid, unsigned int, len,
 #define __NR_sys_sched_setaffinity __NR_sched_setaffinity
 _syscall3(int, sys_sched_setaffinity, pid_t, pid, unsigned int, len,
           unsigned long *, user_mask_ptr);
+#ifndef SCHED_ATTR_SIZE_VER0
 /* sched_attr is not defined in glibc */
 struct sched_attr {
     uint32_t size;
@@ -377,6 +378,7 @@ struct sched_attr {
     uint32_t sched_util_min;
     uint32_t sched_util_max;
 };
+#endif
 #define __NR_sys_sched_getattr __NR_sched_getattr
 _syscall4(int, sys_sched_getattr, pid_t, pid, struct sched_attr *, attr,
           unsigned int, size, unsigned int, flags);


### PR DESCRIPTION
glibc now defines `struct sched_attr`, which makes compilation fail.  i applied a recent qemu patch to make it work until we merge to latest qemu version with the patch applied (it has not been merged on mainline yet afaik).