### PR TITLE
sync CPU state on kvm hw breakpoint

### DIFF
--- a/accel/kvm/kvm-accel-ops.c
+++ b/accel/kvm/kvm-accel-ops.c
@@ -64,6 +64,7 @@ static void *kvm_vcpu_thread_fn(void *arg)
 //// --- Begin LibAFL code ---
                 // cpu_handle_guest_debug(cpu);
 				cpu->stopped = true;
+                kvm_cpu_synchronize_state(cpu);
 				libafl_qemu_trigger_breakpoint(cpu);
 //// --- End LibAFL code ---
             }


### PR DESCRIPTION
@rmalmain fixes wrong breakpoint address returned by `qemu.run()`