### PR TITLE
Rename gen symbols for compatibility with rust 2024

### DIFF
--- a/accel/tcg/translate-all.c
+++ b/accel/tcg/translate-all.c
@@ -285,7 +285,7 @@ static int setjmp_gen_code(CPUArchState *env, TranslationBlock *tb,
 
     //// --- Begin LibAFL code ---
 
-    libafl_qemu_hook_block_run(pc);
+    libafl_qemu_hook_block_pre_run(pc);
 
     //// --- End LibAFL code ---
 
@@ -717,7 +717,7 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
 
 //// --- Begin LibAFL code ---
 
-    libafl_qemu_hook_block_post_gen(tb, pc);
+    libafl_qemu_hook_block_post_run(tb, pc);
 
 //// --- End LibAFL code ---
 

--- a/include/libafl/hook.h
+++ b/include/libafl/hook.h
@@ -54,6 +54,5 @@
 
 // TODO: cleanup this
 extern tcg_target_ulong libafl_gen_cur_pc;
-extern size_t libafl_qemu_hooks_num;
 
 void libafl_tcg_gen_asan(TCGTemp* addr, size_t size);

--- a/include/libafl/hooks/tcg/backdoor.h
+++ b/include/libafl/hooks/tcg/backdoor.h
@@ -10,10 +10,10 @@
 #include "libafl/exit.h"
 #include "libafl/hook.h"
 
-struct libafl_backdoor_hook {
-    // functions
-    void (*gen)(uint64_t data, CPUArchState* cpu, target_ulong pc);
+typedef void (*libafl_backdoor_exec_cb)(uint64_t data, CPUArchState* cpu,
+                                        target_ulong pc);
 
+struct libafl_backdoor_hook {
     // data
     uint64_t data;
     size_t num;
@@ -25,13 +25,7 @@ struct libafl_backdoor_hook {
     struct libafl_backdoor_hook* next;
 };
 
-extern struct libafl_backdoor_hook* libafl_backdoor_hooks;
-
-void libafl_gen_backdoor(target_ulong pc);
-
-size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, CPUArchState* cpu,
-                                             target_ulong pc),
-                                uint64_t data);
+size_t libafl_add_backdoor_hook(libafl_backdoor_exec_cb exec_cb, uint64_t data);
 
 int libafl_qemu_remove_backdoor_hook(size_t num, int invalidate);
 

--- a/include/libafl/hooks/tcg/block.h
+++ b/include/libafl/hooks/tcg/block.h
@@ -10,12 +10,20 @@
 #include "libafl/exit.h"
 #include "libafl/hook.h"
 
+typedef uint64_t (*libafl_block_pre_gen_cb)(uint64_t data, target_ulong pc);
+typedef void (*libafl_block_post_gen_cb)(uint64_t data, target_ulong pc,
+                                         target_ulong block_length);
+
+typedef void (*libafl_block_exec_cb)(uint64_t data, uint64_t id);
+
+typedef size_t (*libafl_block_jit_cb)(uint64_t data, uint64_t id);
+
 struct libafl_block_hook {
     // functions
-    uint64_t (*gen)(uint64_t data, target_ulong pc);
-    void (*post_gen)(uint64_t data, target_ulong pc, target_ulong block_length);
+    libafl_block_pre_gen_cb pre_gen_cb;
+    libafl_block_post_gen_cb post_gen_cb;
 
-    size_t (*jit)(uint64_t data, uint64_t id); // optional opt
+    libafl_block_jit_cb jit_cb; // optional opt
 
     // data
     uint64_t data;
@@ -28,16 +36,15 @@ struct libafl_block_hook {
     struct libafl_block_hook* next;
 };
 
-void libafl_qemu_hook_block_post_gen(TranslationBlock* tb, vaddr pc);
-void libafl_qemu_hook_block_run(target_ulong pc);
+size_t libafl_add_block_hook(libafl_block_pre_gen_cb pre_gen_cb,
+                             libafl_block_post_gen_cb post_gen_cb,
+                             libafl_block_exec_cb exec_cb, uint64_t data);
 
 bool libafl_qemu_block_hook_set_jit(
     size_t num,
-    size_t (*jit)(uint64_t,
-                  uint64_t)); // no param names to avoid to be marked as safe
+    libafl_block_jit_cb jit_cb); // no param names to avoid to be marked as safe
+
 int libafl_qemu_remove_block_hook(size_t num, int invalidate);
-size_t libafl_add_block_hook(uint64_t (*gen)(uint64_t data, target_ulong pc),
-                             void (*post_gen)(uint64_t data, target_ulong pc,
-                                              target_ulong block_length),
-                             void (*exec)(uint64_t data, uint64_t id),
-                             uint64_t data);
+
+void libafl_qemu_hook_block_pre_run(target_ulong pc);
+void libafl_qemu_hook_block_post_run(TranslationBlock* tb, vaddr pc);

--- a/include/libafl/hooks/tcg/cmp.h
+++ b/include/libafl/hooks/tcg/cmp.h
@@ -10,9 +10,20 @@
 #include "libafl/exit.h"
 #include "libafl/hook.h"
 
+typedef uint64_t (*libafl_cmp_gen_cb)(uint64_t data, target_ulong pc,
+                                      size_t size);
+typedef void (*libafl_cmp_exec1_cb)(uint64_t data, uint64_t id, uint8_t v0,
+                                    uint8_t v1);
+typedef void (*libafl_cmp_exec2_cb)(uint64_t data, uint64_t id, uint16_t v0,
+                                    uint16_t v1);
+typedef void (*libafl_cmp_exec4_cb)(uint64_t data, uint64_t id, uint32_t v0,
+                                    uint32_t v1);
+typedef void (*libafl_cmp_exec8_cb)(uint64_t data, uint64_t id, uint64_t v0,
+                                    uint64_t v1);
+
 struct libafl_cmp_hook {
     // functions
-    uint64_t (*gen)(uint64_t data, target_ulong pc, size_t size);
+    libafl_cmp_gen_cb gen_cb;
 
     // data
     uint64_t data;
@@ -29,11 +40,10 @@ struct libafl_cmp_hook {
 };
 
 void libafl_gen_cmp(target_ulong pc, TCGv op0, TCGv op1, MemOp ot);
-size_t libafl_add_cmp_hook(
-    uint64_t (*gen)(uint64_t data, target_ulong pc, size_t size),
-    void (*exec1)(uint64_t data, uint64_t id, uint8_t v0, uint8_t v1),
-    void (*exec2)(uint64_t data, uint64_t id, uint16_t v0, uint16_t v1),
-    void (*exec4)(uint64_t data, uint64_t id, uint32_t v0, uint32_t v1),
-    void (*exec8)(uint64_t data, uint64_t id, uint64_t v0, uint64_t v1),
-    uint64_t data);
+size_t libafl_add_cmp_hook(libafl_cmp_gen_cb gen_cb,
+                           libafl_cmp_exec1_cb exec1_cb,
+                           libafl_cmp_exec2_cb exec2_cb,
+                           libafl_cmp_exec4_cb exec4_cb,
+                           libafl_cmp_exec8_cb exec8_cb, uint64_t data);
+
 int libafl_qemu_remove_cmp_hook(size_t num, int invalidate);

--- a/include/libafl/hooks/tcg/edge.h
+++ b/include/libafl/hooks/tcg/edge.h
@@ -9,10 +9,15 @@
 #include "libafl/exit.h"
 #include "libafl/hook.h"
 
+typedef uint64_t (*libafl_edge_gen_cb)(uint64_t data, target_ulong src,
+                                       target_ulong dst);
+typedef void (*libafl_edge_exec_cb)(uint64_t data, uint64_t id);
+typedef size_t (*libafl_edge_jit_cb)(uint64_t data, uint64_t id);
+
 struct libafl_edge_hook {
     // functions
-    uint64_t (*gen)(uint64_t data, target_ulong src, target_ulong dst);
-    size_t (*jit)(uint64_t data, uint64_t id); // optional opt
+    libafl_edge_gen_cb gen_cb;
+    libafl_edge_jit_cb jit_cb; // optional opt
 
     // data
     uint64_t data;
@@ -31,15 +36,12 @@ TranslationBlock* libafl_gen_edge(CPUState* cpu, target_ulong src_block,
                                   target_ulong cs_base, uint32_t flags,
                                   int cflags);
 
-size_t libafl_add_edge_hook(uint64_t (*gen)(uint64_t data, target_ulong src,
-                                            target_ulong dst),
-                            void (*exec)(uint64_t data, uint64_t id),
-                            uint64_t data);
+size_t libafl_add_edge_hook(libafl_edge_gen_cb gen_cb,
+                            libafl_edge_exec_cb exec_cb, uint64_t data);
 
 bool libafl_qemu_edge_hook_set_jit(
     size_t num,
-    size_t (*jit)(uint64_t,
-                  uint64_t)); // no param names to avoid to be marked as safe
+    libafl_edge_jit_cb jit_cb); // no param names to avoid to be marked as safe
 
 int libafl_qemu_remove_edge_hook(size_t num, int invalidate);
 

--- a/include/libafl/hooks/tcg/read_write.h
+++ b/include/libafl/hooks/tcg/read_write.h
@@ -21,7 +21,7 @@ typedef void (*libafl_rw_execN_cb)(uint64_t data, uint64_t id, target_ulong pc,
 
 struct libafl_rw_hook {
     // functions
-    libafl_rw_gen_cb gen;
+    libafl_rw_gen_cb gen_cb;
 
     // data
     uint64_t data;
@@ -41,15 +41,18 @@ struct libafl_rw_hook {
 void libafl_gen_read(TCGTemp* pc, TCGTemp* addr, MemOpIdx oi);
 void libafl_gen_write(TCGTemp* pc, TCGTemp* addr, MemOpIdx oi);
 
-size_t libafl_add_read_hook(libafl_rw_gen_cb gen, libafl_rw_exec_cb exec1,
-                            libafl_rw_exec_cb exec2, libafl_rw_exec_cb exec4,
-                            libafl_rw_exec_cb exec8, libafl_rw_execN_cb execN,
-                            uint64_t data);
+size_t libafl_add_read_hook(libafl_rw_gen_cb gen_cb, libafl_rw_exec_cb exec1_cb,
+                            libafl_rw_exec_cb exec2_cb,
+                            libafl_rw_exec_cb exec4_cb,
+                            libafl_rw_exec_cb exec8_cb,
+                            libafl_rw_execN_cb execN_cb, uint64_t data);
 
-size_t libafl_add_write_hook(libafl_rw_gen_cb gen, libafl_rw_exec_cb exec1,
-                             libafl_rw_exec_cb exec2, libafl_rw_exec_cb exec4,
-                             libafl_rw_exec_cb exec8, libafl_rw_execN_cb execN,
-                             uint64_t data);
+size_t libafl_add_write_hook(libafl_rw_gen_cb gen_cb,
+                             libafl_rw_exec_cb exec1_cb,
+                             libafl_rw_exec_cb exec2_cb,
+                             libafl_rw_exec_cb exec4_cb,
+                             libafl_rw_exec_cb exec8_cb,
+                             libafl_rw_execN_cb execN_cb, uint64_t data);
 
 int libafl_qemu_remove_read_hook(size_t num, int invalidate);
 int libafl_qemu_remove_write_hook(size_t num, int invalidate);

--- a/libafl/hooks/tcg/backdoor.c
+++ b/libafl/hooks/tcg/backdoor.c
@@ -1,8 +1,8 @@
 #include "libafl/tcg.h"
 #include "libafl/hooks/tcg/backdoor.h"
 
-struct libafl_backdoor_hook* libafl_backdoor_hooks;
-size_t libafl_backdoor_hooks_num = 0;
+static struct libafl_backdoor_hook* libafl_backdoor_hooks;
+static size_t libafl_backdoor_hooks_num = 0;
 
 static TCGHelperInfo libafl_exec_backdoor_hook_info = {
     .func = NULL,
@@ -13,9 +13,7 @@ static TCGHelperInfo libafl_exec_backdoor_hook_info = {
 
 GEN_REMOVE_HOOK(backdoor)
 
-size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, CPUArchState* cpu,
-                                             target_ulong pc),
-                                uint64_t data)
+size_t libafl_add_backdoor_hook(libafl_backdoor_exec_cb exec_cb, uint64_t data)
 {
     struct libafl_backdoor_hook* hook =
         calloc(sizeof(struct libafl_backdoor_hook), 1);
@@ -27,7 +25,7 @@ size_t libafl_add_backdoor_hook(void (*exec)(uint64_t data, CPUArchState* cpu,
 
     memcpy(&hook->helper_info, &libafl_exec_backdoor_hook_info,
            sizeof(TCGHelperInfo));
-    hook->helper_info.func = exec;
+    hook->helper_info.func = exec_cb;
 
     return hook->num;
 }

--- a/libafl/hooks/tcg/instruction.c
+++ b/libafl/hooks/tcg/instruction.c
@@ -11,12 +11,13 @@ static TCGHelperInfo libafl_instruction_info = {
 };
 
 tcg_target_ulong libafl_gen_cur_pc;
-struct libafl_instruction_hook*
+
+static struct libafl_instruction_hook*
     libafl_qemu_instruction_hooks[LIBAFL_TABLES_SIZE];
-size_t libafl_qemu_hooks_num = 0;
+static size_t libafl_qemu_hooks_num = 0;
 
 size_t libafl_qemu_add_instruction_hooks(target_ulong pc,
-                                         libafl_instruction_cb callback,
+                                         libafl_instruction_cb exec_cb,
                                          uint64_t data, int invalidate)
 {
     CPUState* cpu;
@@ -32,7 +33,7 @@ size_t libafl_qemu_add_instruction_hooks(target_ulong pc,
     hk->addr = pc;
     hk->data = data;
     hk->helper_info = libafl_instruction_info;
-    hk->helper_info.func = callback;
+    hk->helper_info.func = exec_cb;
     // TODO check for overflow
     hk->num = libafl_qemu_hooks_num++;
     hk->next = libafl_qemu_instruction_hooks[idx];

--- a/target/i386/kvm/kvm.c
+++ b/target/i386/kvm/kvm.c
@@ -5649,6 +5649,7 @@ static int kvm_handle_debug(X86CPU *cpu,
     } else if (kvm_find_sw_breakpoint(cs, arch_info->pc)) {
         ret = EXCP_DEBUG;
     }
+
     if (ret == 0) {
         cpu_synchronize_state(cs);
         assert(env->exception_nr == -1);


### PR DESCRIPTION
also, use more `typedef` for fn pointers for consistency/readability.