### PR TITLE
Support madvise(MADV_DONTDUMP) when creating core dumps for qemu-user

### DIFF
--- a/include/exec/page-protection.h
+++ b/include/exec/page-protection.h
@@ -38,6 +38,12 @@
  */
 #define PAGE_PASSTHROUGH 0x0800
 
+/*
+ * For linux-user, indicates that the page should not be included in a core
+ * dump.
+ */
+#define PAGE_DONTDUMP   0x1000
+
 #ifdef CONFIG_USER_ONLY
 
 void TSA_NO_TSA mmap_lock(void);

--- a/linux-user/elfload.c
+++ b/linux-user/elfload.c
@@ -4068,6 +4068,10 @@ static size_t vma_dump_size(target_ulong start, target_ulong end,
         return 0;
     }
 
+    if (flags & PAGE_DONTDUMP) {
+        return 0;
+    }
+
     /*
      * Usually we don't dump executable pages as they contain
      * non-writable code that debugger can read directly from

--- a/linux-user/mmap.c
+++ b/linux-user/mmap.c
@@ -1246,6 +1246,11 @@ abi_long target_madvise(abi_ulong start, abi_ulong len_in, int advice)
      */
     mmap_lock();
     switch (advice) {
+    case MADV_DONTDUMP:
+        if (len > 0) {
+            page_set_flags(start, start + len - 1, PAGE_DONTDUMP);
+        }
+        break;
     case MADV_WIPEONFORK:
     case MADV_KEEPONFORK:
         ret = -EINVAL;


### PR DESCRIPTION
When running applications which make large (sparsely populated) address ranges (e.g. when using address sanitizer with LibAFL) the inability to exclude these regions from any core dump can result in very large files which fill the disk. A coredump is obvously very useful for performing a post-mortem when fuzzing.

Whilst the man pages state that madvise provides only a hint (and hence can be ignored), this patch adds support to handle MADV_DONTDUMP and set a corresponding flag in the page flags, thus allowing QEMU to exclude these regions from the core file.