### PR TITLE
Syx snapshot improve

### DIFF
--- a/accel/tcg/cputlb.c
+++ b/accel/tcg/cputlb.c
@@ -1924,11 +1924,11 @@ static void *atomic_mmu_lookup(CPUState *cpu, vaddr addr, MemOpIdx oi,
 
     if (unlikely(tlb_addr & TLB_NOTDIRTY)) {
         notdirty_write(cpu, addr, size, full, retaddr);
-    	//// --- Begin LibAFL code ---
+        //// --- Begin LibAFL code ---
 
         SYX_DEBUG("atomic_mmu_lookup %llx %llx\n", addr, addr+full->xlat_section);
-    	syx_snapshot_dirty_list_add_hostaddr(hostaddr);
-    	//// --- End LibAFL code ---
+        syx_snapshot_dirty_list_add_hostaddr(hostaddr);
+        //// --- End LibAFL code ---
     }
 
     if (unlikely(tlb_addr & TLB_FORCE_SLOW)) {

--- a/hw/core/cpu-system.c
+++ b/hw/core/cpu-system.c
@@ -225,11 +225,9 @@ static int cpu_common_post_load(void *opaque, int version_id)
         //tb_flush(cpu);
         //// --- Begin LibAFL code ---
 
-        // flushing the TBs every restore makes it really slow
-        // TODO handle writes to X code with specific calls to tb_invalidate_phys_addr
-        if (!libafl_devices_is_restoring()) {
-            tb_flush(cpu);
-        }
+        // Only invalidate per CPU virtual JMP cache
+        // Note: Global TB cache will be invalidated by SYX snapshot code
+        tcg_flush_jmp_cache(cpu);
 
         //// --- End LibAFL code ---
     }

--- a/include/exec/cputlb.h
+++ b/include/exec/cputlb.h
@@ -152,6 +152,10 @@ void tlb_flush_all_cpus_synced(CPUState *src_cpu);
 void tlb_flush_page_by_mmuidx(CPUState *cpu, vaddr addr,
                               uint16_t idxmap);
 
+//// --- Begin LibAFL code ---
+void tlb_flush_all_cpus(void);
+//// --- End LibAFL code ---
+
 /**
  * tlb_flush_page_by_mmuidx_all_cpus_synced:
  * @cpu: Originating CPU of the flush

--- a/include/libafl/syx-snapshot/syx-snapshot.h
+++ b/include/libafl/syx-snapshot/syx-snapshot.h
@@ -12,6 +12,7 @@
 
 #include "device-save.h"
 #include "syx-cow-cache.h"
+#include "libafl/syx-misc.h"
 
 #define SYX_SNAPSHOT_COW_CACHE_DEFAULT_CHUNK_SIZE 64
 #define SYX_SNAPSHOT_COW_CACHE_DEFAULT_MAX_BLOCKS (1024 * 1024)


### PR DESCRIPTION
- SYX in `cputlb.c` fixes and streamlining
  - The semantics of SYX snapshot and QEMU`s **notdirty** tracking are basically equal
  - Leverage existing `notdirty_write` for fast snapshot
- Clear TB cache selectively  when restoring snapshot to improve performance
- Change logic in `syx_snapshot_new` as to how i understand `before_fuzz_cache`. As we have a static `syx_snapshot_state`, no need to free. I tested and was able to successfully cache **bdrv** writes before the first snapshot, as intended

I submitted these changes months ago for QEMUv9. It worked for me for a while. 
In here I stripped not related things and concentrate on syx snapshot.