### PR TITLE
fix: memory leak in repeated snapshot restore (vmstate + syx-snapshot)

### DIFF
--- a/libafl/syx-snapshot/syx-snapshot.c
+++ b/libafl/syx-snapshot/syx-snapshot.c
@@ -289,7 +289,7 @@ void syx_snapshot_stop_track(SyxSnapshotTracker* tracker, SyxSnapshot* snapshot)
 {
     for (uint64_t i = 0; i < tracker->length; ++i) {
         if (tracker->tracked_snapshots[i] == snapshot) {
-            for (uint64_t j = i + i; j < tracker->length; ++j) {
+            for (uint64_t j = i + 1; j < tracker->length; ++j) {
                 tracker->tracked_snapshots[j - 1] =
                     tracker->tracked_snapshots[j];
             }

--- a/migration/vmstate-types.c
+++ b/migration/vmstate-types.c
@@ -665,17 +665,23 @@ static int get_qtailq(QEMUFile *f, void *pv, size_t unused_size,
         return -EINVAL;
     }
 
+//// --- Begin LibAFL code ---
     /* Reuse existing elements across repeated restores to avoid leaking. */
     void *existing_elm = *QTAILQ_RAW_FIRST(pv);
+//// --- End LibAFL code ---
 
     while (qemu_get_byte(f)) {
+//// --- Begin LibAFL code ---
         if (existing_elm) {
             elm = existing_elm;
             existing_elm = *QTAILQ_RAW_NEXT(existing_elm, entry_offset);
         } else {
+//// --- End LibAFL code ---
             elm = g_malloc0(size);
+//// --- Begin LibAFL code ---
             QTAILQ_RAW_INSERT_TAIL(pv, elm, entry_offset);
         }
+//// --- End LibAFL code ---
         ret = vmstate_load_state(f, vmsd, elm, version_id, &local_err);
         if (ret) {
             error_report_err(local_err);
@@ -844,6 +850,7 @@ static int get_gtree(QEMUFile *f, void *pv, size_t unused_size,
                 goto key_error;
             }
         }
+//// --- Begin LibAFL code ---
         val = g_tree_lookup(tree, key);
         if (val) {
             ret = vmstate_load_state(f, val_vmsd, val, version_id, &local_err);
@@ -858,6 +865,7 @@ static int get_gtree(QEMUFile *f, void *pv, size_t unused_size,
                 g_free(key);
             }
         } else {
+//// --- End LibAFL code ---
             val = g_malloc0(val_size);
             ret = vmstate_load_state(f, val_vmsd, val, version_id, &local_err);
             if (ret) {
@@ -865,7 +873,9 @@ static int get_gtree(QEMUFile *f, void *pv, size_t unused_size,
                 goto val_error;
             }
             g_tree_insert(tree, key, val);
+//// --- Begin LibAFL code ---
         }
+//// --- End LibAFL code ---
     }
     if (count != nnodes) {
         error_report("%s inconsistent stream when loading the gtree",
@@ -939,26 +949,36 @@ static int get_qlist(QEMUFile *f, void *pv, size_t unused_size,
         return -EINVAL;
     }
 
+//// --- Begin LibAFL code ---
     void *existing_elm = *QLIST_RAW_FIRST(pv);
+//// --- End LibAFL code ---
 
     while (qemu_get_byte(f)) {
+//// --- Begin LibAFL code ---
         if (existing_elm) {
             elm = existing_elm;
             existing_elm = *QLIST_RAW_NEXT(existing_elm, entry_offset);
         } else {
+//// --- End LibAFL code ---
             elm = g_malloc0(size);
+//// --- Begin LibAFL code ---
             if (!prev) {
                 QLIST_RAW_INSERT_HEAD(pv, elm, entry_offset);
             } else {
                 QLIST_RAW_INSERT_AFTER(pv, prev, elm, entry_offset);
             }
         }
+//// --- End LibAFL code ---
         ret = vmstate_load_state(f, vmsd, elm, version_id, &local_err);
         if (ret) {
             error_report_err(local_err);
+//// --- Begin LibAFL code ---
             if (!existing_elm) {
+//// --- End LibAFL code ---
                 g_free(elm);
+//// --- Begin LibAFL code ---
             }
+//// --- End LibAFL code ---
             return ret;
         }
         prev = elm;

--- a/migration/vmstate-types.c
+++ b/migration/vmstate-types.c
@@ -665,14 +665,22 @@ static int get_qtailq(QEMUFile *f, void *pv, size_t unused_size,
         return -EINVAL;
     }
 
+    /* Reuse existing elements across repeated restores to avoid leaking. */
+    void *existing_elm = *QTAILQ_RAW_FIRST(pv);
+
     while (qemu_get_byte(f)) {
-        elm = g_malloc(size);
+        if (existing_elm) {
+            elm = existing_elm;
+            existing_elm = *QTAILQ_RAW_NEXT(existing_elm, entry_offset);
+        } else {
+            elm = g_malloc0(size);
+            QTAILQ_RAW_INSERT_TAIL(pv, elm, entry_offset);
+        }
         ret = vmstate_load_state(f, vmsd, elm, version_id, &local_err);
         if (ret) {
             error_report_err(local_err);
             return ret;
         }
-        QTAILQ_RAW_INSERT_TAIL(pv, elm, entry_offset);
     }
 
     trace_get_qtailq_end(vmsd->name, "end", ret);
@@ -836,13 +844,28 @@ static int get_gtree(QEMUFile *f, void *pv, size_t unused_size,
                 goto key_error;
             }
         }
-        val = g_malloc0(val_size);
-        ret = vmstate_load_state(f, val_vmsd, val, version_id, &local_err);
-        if (ret) {
-            error_report_err(local_err);
-            goto val_error;
+        val = g_tree_lookup(tree, key);
+        if (val) {
+            ret = vmstate_load_state(f, val_vmsd, val, version_id, &local_err);
+            if (ret) {
+                error_report_err(local_err);
+                if (!direct_key) {
+                    g_free(key);
+                }
+                return ret;
+            }
+            if (!direct_key) {
+                g_free(key);
+            }
+        } else {
+            val = g_malloc0(val_size);
+            ret = vmstate_load_state(f, val_vmsd, val, version_id, &local_err);
+            if (ret) {
+                error_report_err(local_err);
+                goto val_error;
+            }
+            g_tree_insert(tree, key, val);
         }
-        g_tree_insert(tree, key, val);
     }
     if (count != nnodes) {
         error_report("%s inconsistent stream when loading the gtree",
@@ -916,18 +939,27 @@ static int get_qlist(QEMUFile *f, void *pv, size_t unused_size,
         return -EINVAL;
     }
 
+    void *existing_elm = *QLIST_RAW_FIRST(pv);
+
     while (qemu_get_byte(f)) {
-        elm = g_malloc(size);
+        if (existing_elm) {
+            elm = existing_elm;
+            existing_elm = *QLIST_RAW_NEXT(existing_elm, entry_offset);
+        } else {
+            elm = g_malloc0(size);
+            if (!prev) {
+                QLIST_RAW_INSERT_HEAD(pv, elm, entry_offset);
+            } else {
+                QLIST_RAW_INSERT_AFTER(pv, prev, elm, entry_offset);
+            }
+        }
         ret = vmstate_load_state(f, vmsd, elm, version_id, &local_err);
         if (ret) {
             error_report_err(local_err);
-            g_free(elm);
+            if (!existing_elm) {
+                g_free(elm);
+            }
             return ret;
-        }
-        if (!prev) {
-            QLIST_RAW_INSERT_HEAD(pv, elm, entry_offset);
-        } else {
-            QLIST_RAW_INSERT_AFTER(pv, prev, elm, entry_offset);
         }
         prev = elm;
     }

--- a/migration/vmstate.c
+++ b/migration/vmstate.c
@@ -126,6 +126,10 @@ static void vmstate_handle_alloc(void *ptr, const VMStateField *field,
         gsize size = vmstate_size(opaque, field);
         size *= vmstate_n_elems(opaque, field);
         if (size) {
+            /* Already allocated by a prior restore: re-allocating would leak it. */
+            if (*(void **)ptr != NULL) {
+                return;
+            }
             *(void **)ptr = g_malloc(size);
         }
     }

--- a/migration/vmstate.c
+++ b/migration/vmstate.c
@@ -126,10 +126,12 @@ static void vmstate_handle_alloc(void *ptr, const VMStateField *field,
         gsize size = vmstate_size(opaque, field);
         size *= vmstate_n_elems(opaque, field);
         if (size) {
+//// --- Begin LibAFL code ---
             /* Already allocated by a prior restore: re-allocating would leak it. */
             if (*(void **)ptr != NULL) {
                 return;
             }
+//// --- End LibAFL code ---
             *(void **)ptr = g_malloc(size);
         }
     }


### PR DESCRIPTION
## Summary

Fixes a critical memory leak (~200MB/min) when using syx fast snapshots for fuzzing. The leak causes OOM kills after ~1 hour on 32GB systems.

### Root Cause

`device_restore_all()` calls `vmstate_load_state()` on every snapshot restore iteration. The vmstate deserialization code was designed for one-shot migration and allocates memory without considering repeated calls:

1. **`vmstate_handle_alloc()`** unconditionally allocates `VMS_ALLOC` buffers via `g_malloc()`, leaking the previous allocation on each restore
2. **`get_qtailq()` / `get_qlist()`** append new list elements without draining old ones, causing unbounded list growth (N elements leaked per restore)
3. **`get_gtree()`** allocates new key/value pairs without reusing existing tree entries
4. **`syx_snapshot_stop_track()`** has an `i + i` typo (should be `i + 1`) that corrupts the tracker array during element removal

### Fix

Reuse existing allocations during repeated restores instead of allocating new ones. Since the serialized device state is identical on every restore, element counts and buffer sizes are always the same:

- **VMS_ALLOC**: skip allocation if pointer is already non-NULL (reuse existing buffer)
- **QTAILQ/QLIST**: walk existing elements in parallel with stream deserialization and overwrite in-place; only allocate if the list needs to grow
- **GTREE**: lookup existing values by key and overwrite in-place; only allocate for new keys
- **stop_track**: fix `i + i` → `i + 1`

### Validation

- `mallinfo2()` confirms heap usage is completely flat across 400K+ restore iterations (was growing ~200MB/min before fix)
- Residual RSS growth (~16MB/min) is from guest RAM page re-faulting after dirty-page restore, not a heap leak
- No performance regression: ~765 exec/s (unchanged)
- Tested with aarch64 virt machine running Linux kernel with KASAN

## Test plan

- [x] Build qemu-libafl-bridge (aarch64-softmmu)
- [x] Run system-mode fuzzer for 60s smoke test — no crashes, correct crash detection
- [x] Monitor RSS over 10 minutes long fuzzing smoke test— heap flat per mallinfo2()
- [x] Verify no regression in exec/sec