### PR TITLE
implement global CPU halting and single-CPU execution for linux-usermode

### DIFF
--- a/include/libafl/exit.h
+++ b/include/libafl/exit.h
@@ -66,6 +66,18 @@ int libafl_qemu_set_breakpoint(vaddr pc);
 int libafl_qemu_remove_breakpoint(vaddr pc);
 void libafl_qemu_trigger_breakpoint(CPUState* cpu);
 void libafl_qemu_breakpoint_run(vaddr pc_next);
+int libafl_qemu_run_single_cpu(int cpu_index);
+
+void libafl_thread_info_list_init(void);
+void libafl_thread_info_list_add(void);
+void libafl_thread_info_list_remove(void);
+
+typedef struct LibAFLThreadInformation {
+    int id;
+    struct libafl_exit_reason *exit_reason;
+    bool *expected_exit;
+    QTAILQ_ENTRY(LibAFLThreadInformation) next;
+} LibAFLThreadInformation;
 
 // Only makes sense to call if an exit was expected
 // Will return NULL if there was no exit expected.

--- a/include/libafl/exit.h
+++ b/include/libafl/exit.h
@@ -66,11 +66,13 @@ int libafl_qemu_set_breakpoint(vaddr pc);
 int libafl_qemu_remove_breakpoint(vaddr pc);
 void libafl_qemu_trigger_breakpoint(CPUState* cpu);
 void libafl_qemu_breakpoint_run(vaddr pc_next);
+#ifdef CONFIG_USER_ONLY
 int libafl_qemu_run_single_cpu(int cpu_index);
 
 void libafl_thread_info_list_init(void);
 void libafl_thread_info_list_add(void);
 void libafl_thread_info_list_remove(void);
+#endif
 
 // Only makes sense to call if an exit was expected
 // Will return NULL if there was no exit expected.

--- a/include/libafl/exit.h
+++ b/include/libafl/exit.h
@@ -67,7 +67,7 @@ int libafl_qemu_remove_breakpoint(vaddr pc);
 void libafl_qemu_trigger_breakpoint(CPUState* cpu);
 void libafl_qemu_breakpoint_run(vaddr pc_next);
 #ifdef CONFIG_USER_ONLY
-int libafl_qemu_run_single_cpu(int cpu_index);
+int libafl_qemu_run_single_cpu(CPUState* cpu);
 
 void libafl_thread_info_list_init(void);
 void libafl_thread_info_list_add(void);

--- a/include/libafl/exit.h
+++ b/include/libafl/exit.h
@@ -72,13 +72,6 @@ void libafl_thread_info_list_init(void);
 void libafl_thread_info_list_add(void);
 void libafl_thread_info_list_remove(void);
 
-typedef struct LibAFLThreadInformation {
-    int id;
-    struct libafl_exit_reason *exit_reason;
-    bool *expected_exit;
-    QTAILQ_ENTRY(LibAFLThreadInformation) next;
-} LibAFLThreadInformation;
-
 // Only makes sense to call if an exit was expected
 // Will return NULL if there was no exit expected.
 CPUState* libafl_last_exit_cpu(void);

--- a/include/libafl/user.h
+++ b/include/libafl/user.h
@@ -5,6 +5,11 @@
 #include "qemu/interval-tree.h"
 
 #include "exec/cpu-defs.h"
+#include "hw/core/cpu.h"
+
+#ifndef LINUX_USER_USER_INTERNALS_H
+extern __thread CPUState *thread_cpu;
+#endif
 
 struct libafl_mapinfo {
     uint64_t start;

--- a/libafl/cpu.c
+++ b/libafl/cpu.c
@@ -179,7 +179,6 @@ int libafl_qemu_run(void)
 }
 
 void libafl_set_qemu_env(CPUArchState* env) { libafl_qemu_env = env; }
-#endif
 
 int libafl_qemu_run_single_cpu(int cpu_index) {
     CPUState *cpu;
@@ -198,3 +197,4 @@ int libafl_qemu_run_single_cpu(int cpu_index) {
     }
     return 0;
 }
+#endif

--- a/libafl/cpu.c
+++ b/libafl/cpu.c
@@ -1,5 +1,6 @@
 #include "qemu/osdep.h"
 #include "hw/core/sysemu-cpu-ops.h"
+#include "hw/core/cpu.h"
 
 #ifdef CONFIG_USER_ONLY
 #include "qemu.h"
@@ -15,6 +16,7 @@
 
 #include "libafl/cpu.h"
 #include "libafl/exit.h"
+#include "linux-user/thread_cpu.h"
 
 static __thread GByteArray* libafl_qemu_mem_buf = NULL;
 static __thread int num_regs = 0;
@@ -172,3 +174,21 @@ int libafl_qemu_run(void)
 
 void libafl_set_qemu_env(CPUArchState* env) { libafl_qemu_env = env; }
 #endif
+
+int libafl_qemu_run_single_cpu(int cpu_index) {
+    CPUState *cpu;
+    CPU_FOREACH(cpu) {
+        if (cpu->cpu_index == cpu_index) {
+            CPUArchState *env = cpu_env(cpu);
+
+            current_cpu = cpu;
+            thread_cpu = cpu;
+            libafl_qemu_env = env;
+
+            cpu_loop(env);
+
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/libafl/cpu.c
+++ b/libafl/cpu.c
@@ -16,7 +16,9 @@
 
 #include "libafl/cpu.h"
 #include "libafl/exit.h"
-#include "linux-user/thread_cpu.h"
+#ifdef CONFIG_USER_ONLY
+#include "libafl/user.h"
+#endif
 
 static __thread GByteArray* libafl_qemu_mem_buf = NULL;
 static __thread int num_regs = 0;

--- a/libafl/cpu.c
+++ b/libafl/cpu.c
@@ -180,21 +180,14 @@ int libafl_qemu_run(void)
 
 void libafl_set_qemu_env(CPUArchState* env) { libafl_qemu_env = env; }
 
-int libafl_qemu_run_single_cpu(int cpu_index) {
-    CPUState *cpu;
-    CPU_FOREACH(cpu) {
-        if (cpu->cpu_index == cpu_index) {
-            CPUArchState *env = cpu_env(cpu);
+int libafl_qemu_run_single_cpu(CPUState *cpu) {
+    CPUArchState *env = cpu_env(cpu);
 
-            current_cpu = cpu;
-            thread_cpu = cpu;
-            libafl_qemu_env = env;
+    current_cpu = cpu;
+    thread_cpu = cpu;
+    libafl_qemu_env = env;
 
-            cpu_loop(env);
-
-            return 1;
-        }
-    }
-    return 0;
+    cpu_loop(env);
+    return 1;
 }
 #endif

--- a/libafl/exit.c
+++ b/libafl/exit.c
@@ -56,15 +56,15 @@ int libafl_qemu_remove_breakpoint(vaddr pc)
 static THREAD_MODIFIER struct libafl_exit_reason last_exit_reason;
 static THREAD_MODIFIER bool expected_exit = false;
 
-typedef struct LibAFLThreadInformation {
+typedef struct libafl_thread_information {
     int id;
     struct libafl_exit_reason *exit_reason;
     bool *expected_exit;
-    QTAILQ_ENTRY(LibAFLThreadInformation) next;
+    QTAILQ_ENTRY(libafl_thread_information) next;
 } LibAFLThreadInformation;
 
-QTAILQ_HEAD(LibAflThreadInformationList, LibAFLThreadInformation);
-static union LibAflThreadInformationList libafl_thread_info_list_head;
+QTAILQ_HEAD(libafl_thread_information_list, libafl_thread_information);
+static union libafl_thread_information_list libafl_thread_info_list_head;
 
 #if defined(TARGET_ARM)
 #define THUMB_MASK(cpu, value) (value | cpu_env(cpu)->thumb)

--- a/libafl/exit.c
+++ b/libafl/exit.c
@@ -3,15 +3,20 @@
 #include "tcg/tcg.h"
 #include "tcg/tcg-op-common.h"
 #include "exec/cpu-common.h"
+#ifdef CONFIG_USER_ONLY
+#include "qemu.h"
+#endif
 
 #include "libafl/exit.h"
 #include "libafl/defs.h"
 #include "libafl/cpu.h"
+#ifdef CONFIG_USER_ONLY
+#include "libafl/user.h"
+#endif
 
 #if !defined(CONFIG_USER_ONLY) && defined(AS_LIB)
 #include "system/runstate.h"
 #endif
-#include "linux-user/thread_cpu.h"
 
 #ifdef CONFIG_USER_ONLY
 #define THREAD_MODIFIER __thread

--- a/libafl/exit.c
+++ b/libafl/exit.c
@@ -56,8 +56,15 @@ int libafl_qemu_remove_breakpoint(vaddr pc)
 static THREAD_MODIFIER struct libafl_exit_reason last_exit_reason;
 static THREAD_MODIFIER bool expected_exit = false;
 
+typedef struct LibAFLThreadInformation {
+    int id;
+    struct libafl_exit_reason *exit_reason;
+    bool *expected_exit;
+    QTAILQ_ENTRY(LibAFLThreadInformation) next;
+} LibAFLThreadInformation;
+
 QTAILQ_HEAD(LibAflThreadInformationList, LibAFLThreadInformation);
-static struct LibAflThreadInformationList libafl_thread_info_list_head;
+static union LibAflThreadInformationList libafl_thread_info_list_head;
 
 #if defined(TARGET_ARM)
 #define THUMB_MASK(cpu, value) (value | cpu_env(cpu)->thumb)
@@ -217,7 +224,20 @@ void libafl_thread_info_list_add(void) {
 }
 
 void libafl_thread_info_list_remove(void) {
-    // TODO
+    LibAFLThreadInformation *thread_info;
+
+    int current_id = thread_cpu->cpu_index;
+
+    QTAILQ_FOREACH(thread_info, &libafl_thread_info_list_head, next) {
+        if (thread_info->id == current_id) {
+            QTAILQ_REMOVE(&libafl_thread_info_list_head, thread_info, next);
+
+            // avoid memory leak
+            g_free(thread_info);
+
+            break;
+        }
+    }
 }
 
 void libafl_qemu_breakpoint_run(vaddr pc_next)

--- a/libafl/exit.c
+++ b/libafl/exit.c
@@ -204,6 +204,7 @@ struct libafl_exit_reason* libafl_get_exit_reason(void)
     return NULL;
 }
 
+#ifdef CONFIG_USER_ONLY
 void libafl_thread_info_list_init(void) {
     LibAFLThreadInformation *thread_info = g_new0(LibAFLThreadInformation, 1);
     thread_info->exit_reason = &last_exit_reason;
@@ -239,6 +240,7 @@ void libafl_thread_info_list_remove(void) {
         }
     }
 }
+#endif
 
 void libafl_qemu_breakpoint_run(vaddr pc_next)
 {

--- a/libafl/exit.c
+++ b/libafl/exit.c
@@ -11,6 +11,7 @@
 #if !defined(CONFIG_USER_ONLY) && defined(AS_LIB)
 #include "system/runstate.h"
 #endif
+#include "linux-user/thread_cpu.h"
 
 #ifdef CONFIG_USER_ONLY
 #define THREAD_MODIFIER __thread
@@ -55,6 +56,9 @@ int libafl_qemu_remove_breakpoint(vaddr pc)
 static THREAD_MODIFIER struct libafl_exit_reason last_exit_reason;
 static THREAD_MODIFIER bool expected_exit = false;
 
+QTAILQ_HEAD(LibAflThreadInformationList, LibAFLThreadInformation);
+static struct LibAflThreadInformationList libafl_thread_info_list_head;
+
 #if defined(TARGET_ARM)
 #define THUMB_MASK(cpu, value) (value | cpu_env(cpu)->thumb)
 #else
@@ -84,12 +88,26 @@ static void prepare_qemu_exit(CPUState* cpu, vaddr next_pc)
     qemu_system_return_request();
 #endif
 
-    // in usermode, this may be called from the syscall hook, thus already out
-    // of the cpu_exec but still in the cpu_loop
-    if (cpu->running) {
-        cpu->exception_index = EXCP_LIBAFL_EXIT;
-        cpu_loop_exit(cpu);
+    LibAFLThreadInformation *info;
+    QTAILQ_FOREACH(info, &libafl_thread_info_list_head, next) {
+        info->exit_reason->kind = last_exit_reason.kind;
+        info->exit_reason->data.breakpoint.addr = next_pc;
+        info->exit_reason->cpu = cpu;
+        info->exit_reason->next_pc = next_pc;
+        *(info->expected_exit) = true;
     }
+
+    CPUState *c;
+    CPU_FOREACH(c) {
+        qemu_cpu_kick(c);
+        cpu_exit(c);
+        if (c->running) {
+            c->exception_index = EXCP_LIBAFL_EXIT;
+            cpu_exit(c);
+        }
+    }
+
+    cpu_loop_exit(last_exit_reason.cpu);
 }
 
 CPUState* libafl_last_exit_cpu(void)
@@ -162,7 +180,12 @@ void libafl_qemu_trigger_breakpoint(CPUState* cpu)
 void libafl_exit_signal_vm_start(void)
 {
     last_exit_reason.cpu = NULL;
-    expected_exit = false;
+
+    LibAFLThreadInformation *info;
+    QTAILQ_FOREACH(info, &libafl_thread_info_list_head, next) {
+        info->exit_reason->cpu = NULL;
+        *(info->expected_exit) = false;
+    }
 }
 
 struct libafl_exit_reason* libafl_get_exit_reason(void)
@@ -172,6 +195,29 @@ struct libafl_exit_reason* libafl_get_exit_reason(void)
     }
 
     return NULL;
+}
+
+void libafl_thread_info_list_init(void) {
+    LibAFLThreadInformation *thread_info = g_new0(LibAFLThreadInformation, 1);
+    thread_info->exit_reason = &last_exit_reason;
+    thread_info->expected_exit = &expected_exit;
+    thread_info->id = 0;
+
+    QTAILQ_INIT(&libafl_thread_info_list_head);
+    QTAILQ_INSERT_HEAD(&libafl_thread_info_list_head, thread_info, next);
+}
+
+void libafl_thread_info_list_add(void) {
+    LibAFLThreadInformation *thread_info = g_new0(LibAFLThreadInformation, 1);
+    thread_info->exit_reason = &last_exit_reason;
+    thread_info->expected_exit = &expected_exit;
+    thread_info->id = thread_cpu->cpu_index;
+
+    QTAILQ_INSERT_TAIL(&libafl_thread_info_list_head, thread_info, next);
+}
+
+void libafl_thread_info_list_remove(void) {
+    // TODO
 }
 
 void libafl_qemu_breakpoint_run(vaddr pc_next)

--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -61,6 +61,7 @@
 //// --- End LibAFL code ---
 #include "libafl/cpu.h"
 #include "libafl/user.h"
+#include "libafl/exit.h"
 //// --- Begin LibAFL code ---
 
 #ifdef CONFIG_SEMIHOSTING
@@ -1070,6 +1071,7 @@ int main(int argc, char **argv, char **envp)
     //// --- Begin LibAFL code ---
 
     libafl_set_qemu_env(env);
+    libafl_thread_info_list_init();
 
 #ifndef AS_LIB
     return libafl_qemu_main();

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -151,6 +151,7 @@
 
 #include "libafl/hooks/syscall.h"
 #include "libafl/hooks/thread.h"
+#include "libafl/exit.h"
 
 //// --- End LibAFL code ---
 
@@ -6719,6 +6720,7 @@ static void *clone_func(void *arg)
 
     //// --- Begin LibAFL code ---
 
+    libafl_thread_info_list_add();
     if (libafl_hook_new_thread_run(env, info->tid)) {
         cpu_loop(env);
     }
@@ -6877,6 +6879,10 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
         fork_start();
         ret = fork();
         if (ret == 0) {
+            //// --- Begin LibAFL code ---
+            libafl_thread_info_list_add();
+            //// --- End LibAFL code ---
+
             /* Child Process.  */
             cpu_clone_regs_child(env, newsp, flags);
             fork_end(ret);

--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -9496,6 +9496,9 @@ static abi_long do_syscall1(CPUArchState *cpu_env, int num, abi_long arg1,
            and _exit_group is used for application termination.
            Do thread termination if we have more then one thread.  */
 
+        //// --- Begin LibAFL code ---
+        libafl_thread_info_list_remove();
+        //// --- End LibAFL code ---
         if (block_signals()) {
             return -QEMU_ERESTARTSYS;
         }

--- a/linux-user/thread_cpu.h
+++ b/linux-user/thread_cpu.h
@@ -1,2 +1,0 @@
-#include "hw/core/cpu.h"
-extern __thread CPUState *thread_cpu;

--- a/linux-user/thread_cpu.h
+++ b/linux-user/thread_cpu.h
@@ -1,0 +1,2 @@
+#include "hw/core/cpu.h"
+extern __thread CPUState *thread_cpu;


### PR DESCRIPTION
This PR allows breakpoints in different threads to halt the execution of all threads and fixes Issue #122. Furthermore, a function `run_single_cpu` is added which allows after a all threads halt to resume the execution of a single thread. This is useful for i.e. fuzzing parsers located which are running in a single thread in a large multithreaded application.

Companion patch to libafl [here](https://github.com/AFLplusplus/LibAFL/pull/3836).