### PR TITLE
Handle multiple instruction hooks registered at same address

### DIFF
--- a/libafl/hooks/tcg/instruction.c
+++ b/libafl/hooks/tcg/instruction.c
@@ -31,17 +31,8 @@ size_t libafl_qemu_add_instruction_hooks(vaddr pc,
 
     size_t idx = LIBAFL_TABLES_HASH(pc);
 
-    // Avoid duplicate hook registrations: if a hook with the same (addr,
-    // callback) already exists, keep the existing one.
-    struct libafl_instruction_hook* hk = libafl_qemu_instruction_hooks[idx];
-    while (hk) {
-        if (hk->addr == pc && hk->helper_info.func == exec_cb) {
-            return hk->num;
-        }
-        hk = hk->next;
-    }
-
-    hk = calloc(sizeof(struct libafl_instruction_hook), 1);
+    struct libafl_instruction_hook* hk =
+        calloc(sizeof(struct libafl_instruction_hook), 1);
     hk->addr = pc;
     hk->data = data;
     hk->helper_info = libafl_instruction_info;

--- a/libafl/hooks/tcg/instruction.c
+++ b/libafl/hooks/tcg/instruction.c
@@ -31,8 +31,17 @@ size_t libafl_qemu_add_instruction_hooks(vaddr pc,
 
     size_t idx = LIBAFL_TABLES_HASH(pc);
 
-    struct libafl_instruction_hook* hk =
-        calloc(sizeof(struct libafl_instruction_hook), 1);
+    // Avoid duplicate hook registrations: if a hook with the same (addr,
+    // callback) already exists, keep the existing one.
+    struct libafl_instruction_hook* hk = libafl_qemu_instruction_hooks[idx];
+    while (hk) {
+        if (hk->addr == pc && hk->helper_info.func == exec_cb) {
+            return hk->num;
+        }
+        hk = hk->next;
+    }
+
+    hk = calloc(sizeof(struct libafl_instruction_hook), 1);
     hk->addr = pc;
     hk->data = data;
     hk->helper_info = libafl_instruction_info;

--- a/libafl/hooks/tcg/instruction.c
+++ b/libafl/hooks/tcg/instruction.c
@@ -116,12 +116,15 @@ libafl_search_instruction_hook(vaddr addr)
 
 void libafl_qemu_hook_instruction_run(vaddr pc_next)
 {
-    struct libafl_instruction_hook* hk =
+    struct libafl_instruction_hook* hook =
         libafl_search_instruction_hook(pc_next);
-    if (hk) {
-        TCGv_i64 tmp0 = tcg_constant_i64(hk->data);
-        TCGv tmp1 = tcg_constant_tl(pc_next);
-        TCGTemp* tmp2[2] = {tcgv_i64_temp(tmp0), tcgv_tl_temp(tmp1)};
-        tcg_gen_callN(hk->helper_info.func, &hk->helper_info, NULL, tmp2);
+    while (hook) {
+        if (hook->addr == pc_next) {
+            TCGv_i64 tmp0 = tcg_constant_i64(hook->data);
+            TCGv tmp1 = tcg_constant_tl(pc_next);
+            TCGTemp* tmp2[2] = {tcgv_i64_temp(tmp0), tcgv_tl_temp(tmp1)};
+            tcg_gen_callN(hook->helper_info.func, &hook->helper_info, NULL, tmp2);
+        }
+        hook = hook->next;
     }
 }


### PR DESCRIPTION
Bug: When multiple instruction hooks are registered at the same address, the current implementation of libafl_qemu_hook_instruction_run() selects only one hook, causing the others to be skipped.

Fix: Like the other hook dispatcher implementations, iterate through all matching hooks using a while loop.

Fix in LibAFL: https://github.com/AFLplusplus/LibAFL/pull/3849